### PR TITLE
Fixed issue #3, updated golang version compatibility

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -71,6 +71,26 @@ var testCases []TestCase = []TestCase{
 						},
 					},
 				},
+				{
+					Name: "package/name/other",
+					Time: 151,
+					Tests: []Test{
+						{
+							Name:   "TestThree",
+							Time:   20,
+							Result: FAIL,
+							Output: []string{
+								"file_test.go:11: Simpler error message",
+							},
+						},
+						{
+							Name:   "TestFour",
+							Time:   130,
+							Result: PASS,
+							Output: []string{},
+						},
+					},
+				},
 			},
 		},
 	},
@@ -163,7 +183,7 @@ func loadTestReport(name string) (string, error) {
 	}
 
 	// replace value="1.0" With actual version
-	report := strings.Replace(string(contents), `value="1.0"`, fmt.Sprintf(`value="%s"`, runtime.Version()), 1)
+	report := strings.Replace(string(contents), `value="1.0"`, fmt.Sprintf(`value="%s"`, runtime.Version()), len(testCases))
 
 	return report, nil
 }

--- a/parser.go
+++ b/parser.go
@@ -34,7 +34,7 @@ type Test struct {
 
 var (
 	regexStatus = regexp.MustCompile(`^--- (PASS|FAIL): (.+) \((\d+\.\d+) seconds\)$`)
-	regexResult = regexp.MustCompile(`^(ok|FAIL)\s+(.+)\s(\d+\.\d+)s$`)
+	regexResult = regexp.MustCompile(`^(ok|FAIL)\s+(.+)\s(\d+\.\d+)s`)
 )
 
 func Parse(r io.Reader) (*Report, error) {

--- a/tests/01-report.xml
+++ b/tests/01-report.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite tests="2" failures="0" time="0.160" name="package/name">
-	<properties>
-		<property name="go.version" value="1.0"></property>
-	</properties>
-	<testcase classname="name" name="TestOne" time="0.060"></testcase>
-	<testcase classname="name" name="TestTwo" time="0.100"></testcase>
-</testsuite>
+<testsuites tests="2" failures="0" time="0.160" name="package/name">
+	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="name" name="TestOne" time="0.060"></testcase>
+		<testcase classname="name" name="TestTwo" time="0.100"></testcase>
+	</testsuite>
+</testsuites>

--- a/tests/02-fail.txt
+++ b/tests/02-fail.txt
@@ -9,3 +9,11 @@
 FAIL
 exit status 1
 FAIL	package/name 0.151s
+=== RUN TestThree
+--- FAIL: TestThree (0.02 seconds)
+	file_test.go:11: Simpler error message
+=== RUN TestFour
+--- PASS: TestFour (0.13 seconds)
+FAIL
+exit status 1
+FAIL	package/name/other 0.151s

--- a/tests/02-report.xml
+++ b/tests/02-report.xml
@@ -1,13 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuite tests="2" failures="1" time="0.151" name="package/name">
-	<properties>
-		<property name="go.version" value="1.0"></property>
-	</properties>
-	<testcase classname="name" name="TestOne" time="0.020">
-		<failure message="Failed" type="">file_test.go:11: Error message
-file_test.go:11: Longer
-	error
-	message.</failure>
-	</testcase>
-	<testcase classname="name" name="TestTwo" time="0.130"></testcase>
-</testsuite>
+<testsuites tests="4" failures="2" time="0.302" name="package/name">
+	<testsuite tests="2" failures="1" time="0.151" name="package/name">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="name" name="TestOne" time="0.020">
+			<failure message="Failed">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;&#x9;error&#xA;&#x9;message.</failure>
+		</testcase>
+		<testcase classname="name" name="TestTwo" time="0.130"></testcase>
+	</testsuite>
+	<testsuite tests="2" failures="1" time="0.151" name="package/name/other">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="other" name="TestThree" time="0.020">
+			<failure message="Failed">file_test.go:11: Simpler error message</failure>
+		</testcase>
+		<testcase classname="other" name="TestFour" time="0.130"></testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
Updated to make work with go 1.1+
Fixed problem (issue #3) with not using a root element container for test suites.