### PR TITLE
support compiled test

### DIFF
--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -7,16 +7,18 @@ import (
 )
 
 var noXmlHeader bool
+var packageName string
 
 func init() {
 	flag.BoolVar(&noXmlHeader, "no-xml-header", false, "do not print xml header")
+	flag.StringVar(&packageName, "package-name", "", "specify a package name (compiled test have no package name in output)")
 }
 
 func main() {
 	flag.Parse()
 
 	// Read input
-	report, err := Parse(os.Stdin)
+	report, err := Parse(os.Stdin, packageName)
 	if err != nil {
 		fmt.Printf("Error reading input: %s\n", err)
 		os.Exit(1)

--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -15,6 +15,7 @@ type TestCase struct {
 	reportName  string
 	report      *Report
 	noXmlHeader bool
+	packageName string
 }
 
 var testCases []TestCase = []TestCase{
@@ -156,6 +157,33 @@ var testCases []TestCase = []TestCase{
 		},
 		noXmlHeader: true,
 	},
+	{
+		name:       "06-compiled_test.txt",
+		reportName: "06-report.xml",
+		report: &Report{
+			Packages: []Package{
+				{
+					Name: "test/package",
+					Time: 160,
+					Tests: []Test{
+						{
+							Name:   "TestOne",
+							Time:   60,
+							Result: PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestTwo",
+							Time:   100,
+							Result: PASS,
+							Output: []string{},
+						},
+					},
+				},
+			},
+		},
+		packageName: "test/package",
+	},
 }
 
 func TestParser(t *testing.T) {
@@ -165,7 +193,7 @@ func TestParser(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		report, err := Parse(file)
+		report, err := Parse(file, testCase.packageName)
 		if err != nil {
 			t.Fatalf("error parsing: %s", err)
 		}

--- a/tests/06-compiled_test.txt
+++ b/tests/06-compiled_test.txt
@@ -1,0 +1,5 @@
+=== RUN TestOne
+--- PASS: TestOne (0.06s)
+=== RUN TestTwo
+--- PASS: TestTwo (0.10s)
+PASS

--- a/tests/06-report.xml
+++ b/tests/06-report.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite tests="2" failures="0" time="0.160" name="test/package">
+	<properties>
+		<property name="go.version" value="1.0"></property>
+	</properties>
+	<testcase classname="package" name="TestOne" time="0.060"></testcase>
+	<testcase classname="package" name="TestTwo" time="0.100"></testcase>
+</testsuite>


### PR DESCRIPTION
Compiled test's output have no result line, which contains total time of package and name of package

This PR makes 2 changes:
1. use sum of individual tests' time as total time of package
2. add a new flag -package-name