### PR TITLE
adding 'set-exit-code' flag

### DIFF
--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -9,11 +9,13 @@ import (
 var (
 	noXMLHeader bool
 	packageName string
+	setExitCode bool
 )
 
 func init() {
 	flag.BoolVar(&noXMLHeader, "no-xml-header", false, "do not print xml header")
 	flag.StringVar(&packageName, "package-name", "", "specify a package name (compiled test have no package name in output)")
+	flag.BoolVar(&setExitCode, "set-exit-code", false, "set exit code to 1 if tests failed")
 }
 
 func main() {
@@ -30,6 +32,10 @@ func main() {
 	err = JUnitReportXML(report, noXMLHeader, os.Stdout)
 	if err != nil {
 		fmt.Printf("Error writing XML: %s\n", err)
+		os.Exit(1)
+	}
+
+	if setExitCode && report.Failures() > 0 {
 		os.Exit(1)
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -148,3 +148,18 @@ func findTest(tests []*Test, name string) *Test {
 	}
 	return nil
 }
+
+// Failures counts the number of failed tests in this report
+func (r *Report) Failures() int {
+	count := 0
+
+	for _, p := range r.Packages {
+		for _, t := range p.Tests {
+			if t.Result == FAIL {
+				count++
+			}
+		}
+	}
+
+	return count
+}


### PR DESCRIPTION
Defaults to false. When true, sets the exit-code to 1 if any tests
failed. This is useful for automation.