### PR TITLE
moving parser into subpackage

### DIFF
--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+
+	"github.com/jstemmer/go-junit-report/parser"
 )
 
 var (
@@ -22,7 +24,7 @@ func main() {
 	flag.Parse()
 
 	// Read input
-	report, err := Parse(os.Stdin, packageName)
+	report, err := parser.Parse(os.Stdin, packageName)
 	if err != nil {
 		fmt.Printf("Error reading input: %s\n", err)
 		os.Exit(1)

--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -8,12 +8,14 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/jstemmer/go-junit-report/parser"
 )
 
 type TestCase struct {
 	name        string
 	reportName  string
-	report      *Report
+	report      *parser.Report
 	noXMLHeader bool
 	packageName string
 }
@@ -22,22 +24,22 @@ var testCases = []TestCase{
 	{
 		name:       "01-pass.txt",
 		reportName: "01-report.xml",
-		report: &Report{
-			Packages: []Package{
+		report: &parser.Report{
+			Packages: []parser.Package{
 				{
 					Name: "package/name",
 					Time: 160,
-					Tests: []*Test{
+					Tests: []*parser.Test{
 						{
 							Name:   "TestZ",
 							Time:   60,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 						{
 							Name:   "TestA",
 							Time:   100,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 					},
@@ -48,16 +50,16 @@ var testCases = []TestCase{
 	{
 		name:       "02-fail.txt",
 		reportName: "02-report.xml",
-		report: &Report{
-			Packages: []Package{
+		report: &parser.Report{
+			Packages: []parser.Package{
 				{
 					Name: "package/name",
 					Time: 151,
-					Tests: []*Test{
+					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
 							Time:   20,
-							Result: FAIL,
+							Result: parser.FAIL,
 							Output: []string{
 								"file_test.go:11: Error message",
 								"file_test.go:11: Longer",
@@ -68,7 +70,7 @@ var testCases = []TestCase{
 						{
 							Name:   "TestTwo",
 							Time:   130,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 					},
@@ -79,16 +81,16 @@ var testCases = []TestCase{
 	{
 		name:       "03-skip.txt",
 		reportName: "03-report.xml",
-		report: &Report{
-			Packages: []Package{
+		report: &parser.Report{
+			Packages: []parser.Package{
 				{
 					Name: "package/name",
 					Time: 150,
-					Tests: []*Test{
+					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
 							Time:   20,
-							Result: SKIP,
+							Result: parser.SKIP,
 							Output: []string{
 								"file_test.go:11: Skip message",
 							},
@@ -96,7 +98,7 @@ var testCases = []TestCase{
 						{
 							Name:   "TestTwo",
 							Time:   130,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 					},
@@ -107,22 +109,22 @@ var testCases = []TestCase{
 	{
 		name:       "04-go_1_4.txt",
 		reportName: "04-report.xml",
-		report: &Report{
-			Packages: []Package{
+		report: &parser.Report{
+			Packages: []parser.Package{
 				{
 					Name: "package/name",
 					Time: 160,
-					Tests: []*Test{
+					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
 							Time:   60,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 						{
 							Name:   "TestTwo",
 							Time:   100,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 					},
@@ -133,22 +135,22 @@ var testCases = []TestCase{
 	{
 		name:       "05-no_xml_header.txt",
 		reportName: "05-report.xml",
-		report: &Report{
-			Packages: []Package{
+		report: &parser.Report{
+			Packages: []parser.Package{
 				{
 					Name: "package/name",
 					Time: 160,
-					Tests: []*Test{
+					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
 							Time:   60,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 						{
 							Name:   "TestTwo",
 							Time:   100,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 					},
@@ -160,22 +162,22 @@ var testCases = []TestCase{
 	{
 		name:       "06-mixed.txt",
 		reportName: "06-report.xml",
-		report: &Report{
-			Packages: []Package{
+		report: &parser.Report{
+			Packages: []parser.Package{
 				{
 					Name: "package/name1",
 					Time: 160,
-					Tests: []*Test{
+					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
 							Time:   60,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 						{
 							Name:   "TestTwo",
 							Time:   100,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 					},
@@ -183,11 +185,11 @@ var testCases = []TestCase{
 				{
 					Name: "package/name2",
 					Time: 151,
-					Tests: []*Test{
+					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
 							Time:   20,
-							Result: FAIL,
+							Result: parser.FAIL,
 							Output: []string{
 								"file_test.go:11: Error message",
 								"file_test.go:11: Longer",
@@ -198,7 +200,7 @@ var testCases = []TestCase{
 						{
 							Name:   "TestTwo",
 							Time:   130,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 					},
@@ -210,22 +212,22 @@ var testCases = []TestCase{
 	{
 		name:       "07-compiled_test.txt",
 		reportName: "07-report.xml",
-		report: &Report{
-			Packages: []Package{
+		report: &parser.Report{
+			Packages: []parser.Package{
 				{
 					Name: "test/package",
 					Time: 160,
-					Tests: []*Test{
+					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
 							Time:   60,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 						{
 							Name:   "TestTwo",
 							Time:   100,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{},
 						},
 					},
@@ -237,22 +239,22 @@ var testCases = []TestCase{
 	{
 		name:       "08-parallel.txt",
 		reportName: "08-report.xml",
-		report: &Report{
-			Packages: []Package{
+		report: &parser.Report{
+			Packages: []parser.Package{
 				{
 					Name: "github.com/dmitris/test-go-junit-report",
 					Time: 440,
-					Tests: []*Test{
+					Tests: []*parser.Test{
 						{
 							Name:   "TestDoFoo",
 							Time:   270,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{"cov_test.go:10: DoFoo log 1", "cov_test.go:10: DoFoo log 2"},
 						},
 						{
 							Name:   "TestDoFoo2",
 							Time:   160,
-							Result: PASS,
+							Result: parser.PASS,
 							Output: []string{"cov_test.go:21: DoFoo2 log 1", "cov_test.go:21: DoFoo2 log 2"},
 						},
 					},
@@ -271,7 +273,7 @@ func TestParser(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		report, err := Parse(file, testCase.packageName)
+		report, err := parser.Parse(file, testCase.packageName)
 		if err != nil {
 			t.Fatalf("error parsing: %s", err)
 		}

--- a/junit-formatter.go
+++ b/junit-formatter.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"runtime"
 	"strings"
+
+	"github.com/jstemmer/go-junit-report/parser"
 )
 
 // JUnitTestSuites is a collection of JUnit test suites.
@@ -57,7 +59,7 @@ type JUnitFailure struct {
 
 // JUnitReportXML writes a JUnit xml representation of the given report to w
 // in the format described at http://windyroad.org/dl/Open%20Source/JUnit.xsd
-func JUnitReportXML(report *Report, noXMLHeader bool, w io.Writer) error {
+func JUnitReportXML(report *parser.Report, noXMLHeader bool, w io.Writer) error {
 	suites := JUnitTestSuites{}
 
 	// convert Report to JUnit test suites
@@ -88,7 +90,7 @@ func JUnitReportXML(report *Report, noXMLHeader bool, w io.Writer) error {
 				Failure:   nil,
 			}
 
-			if test.Result == FAIL {
+			if test.Result == parser.FAIL {
 				ts.Failures++
 				testCase.Failure = &JUnitFailure{
 					Message:  "Failed",
@@ -97,7 +99,7 @@ func JUnitReportXML(report *Report, noXMLHeader bool, w io.Writer) error {
 				}
 			}
 
-			if test.Result == SKIP {
+			if test.Result == parser.SKIP {
 				testCase.SkipMessage = &JUnitSkipMessage{strings.Join(test.Output, "\n")}
 			}
 
@@ -126,9 +128,9 @@ func JUnitReportXML(report *Report, noXMLHeader bool, w io.Writer) error {
 	return nil
 }
 
-func countFailures(tests []Test) (result int) {
+func countFailures(tests []parser.Test) (result int) {
 	for _, test := range tests {
-		if test.Result == FAIL {
+		if test.Result == parser.FAIL {
 			result++
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,4 +1,4 @@
-package main
+package parser
 
 import (
 	"bufio"


### PR DESCRIPTION
I really like this code, and would like to use the `go test` parsing bit in my own app. 

This PR moves it into the `parser` subpackage so it can be included as a library elsewhere.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jstemmer/go-junit-report/13)
<!-- Reviewable:end -->
