### PR TITLE
Extract and report coverage information.

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -260,6 +260,73 @@ var testCases = []TestCase{
 			},
 		},
 	},
+	{
+		name:       "09-coverage.txt",
+		reportName: "09-report.xml",
+		report: &Report{
+			Packages: []Package{
+				{
+					Name: "package/name",
+					Time: 160,
+					Tests: []*Test{
+						{
+							Name:   "TestZ",
+							Time:   60,
+							Result: PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestA",
+							Time:   100,
+							Result: PASS,
+							Output: []string{},
+						},
+					},
+					CoveragePct: "13.37",
+				},
+			},
+		},
+	},
+	{
+		name:       "10-multipkg-coverage.txt",
+		reportName: "10-report.xml",
+		report: &Report{
+			Packages: []Package{
+				{
+					Name: "package1/foo",
+					Time: 400,
+					Tests: []*Test{
+						{
+							Name:   "TestA",
+							Time:   100,
+							Result: PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestB",
+							Time:   300,
+							Result: PASS,
+							Output: []string{},
+						},
+					},
+					CoveragePct: "10.0",
+				},
+				{
+					Name: "package2/bar",
+					Time: 4200,
+					Tests: []*Test{
+						{
+							Name:   "TestC",
+							Time:   4200,
+							Result: PASS,
+							Output: []string{},
+						},
+					},
+					CoveragePct: "99.8",
+				},
+			},
+		},
+	},
 }
 
 func TestParser(t *testing.T) {
@@ -320,6 +387,9 @@ func TestParser(t *testing.T) {
 				if testOutput != expTestOutput {
 					t.Errorf("Test.Output ==\n%s\n, want\n%s", testOutput, expTestOutput)
 				}
+			}
+			if pkg.CoveragePct != expPkg.CoveragePct {
+				t.Errorf("Package.CoveragePct == %s, want %s", pkg.CoveragePct, expPkg.CoveragePct)
 			}
 		}
 	}

--- a/junit-formatter.go
+++ b/junit-formatter.go
@@ -78,6 +78,9 @@ func JUnitReportXML(report *Report, noXMLHeader bool, w io.Writer) error {
 
 		// properties
 		ts.Properties = append(ts.Properties, JUnitProperty{"go.version", runtime.Version()})
+		if pkg.CoveragePct != "" {
+			ts.Properties = append(ts.Properties, JUnitProperty{"coverage.statements.pct", pkg.CoveragePct})
+		}
 
 		// individual test cases
 		for _, test := range pkg.Tests {

--- a/tests/09-coverage.txt
+++ b/tests/09-coverage.txt
@@ -1,0 +1,7 @@
+=== RUN TestZ
+--- PASS: TestZ (0.06 seconds)
+=== RUN TestA
+--- PASS: TestA (0.10 seconds)
+PASS
+coverage: 13.37% of statements
+ok  	package/name 0.160s

--- a/tests/09-report.xml
+++ b/tests/09-report.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+			<property name="coverage.statements.pct" value="13.37"></property>
+		</properties>
+		<testcase classname="name" name="TestZ" time="0.060"></testcase>
+		<testcase classname="name" name="TestA" time="0.100"></testcase>
+	</testsuite>
+</testsuites>

--- a/tests/10-multipkg-coverage.txt
+++ b/tests/10-multipkg-coverage.txt
@@ -1,0 +1,12 @@
+=== RUN TestA
+--- PASS: TestA (0.10 seconds)
+=== RUN TestB
+--- PASS: TestB (0.30 seconds)
+PASS
+coverage: 10% of statements
+ok  	package1/foo 0.400s  coverage: 10.0% of statements
+=== RUN TestC
+--- PASS: TestC (4.20 seconds)
+PASS
+coverage: 99.8% of statements
+ok  	package2/bar 4.200s  coverage: 99.8% of statements

--- a/tests/10-report.xml
+++ b/tests/10-report.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="2" failures="0" time="0.400" name="package1/foo">
+		<properties>
+			<property name="go.version" value="go1.4.2"></property>
+			<property name="coverage.statements.pct" value="10.0"></property>
+		</properties>
+		<testcase classname="foo" name="TestA" time="0.100"></testcase>
+		<testcase classname="foo" name="TestB" time="0.300"></testcase>
+	</testsuite>
+	<testsuite tests="1" failures="0" time="4.200" name="package2/bar">
+		<properties>
+			<property name="go.version" value="go1.4.2"></property>
+			<property name="coverage.statements.pct" value="99.8"></property>
+		</properties>
+		<testcase classname="bar" name="TestC" time="4.200"></testcase>
+	</testsuite>
+</testsuites>

--- a/tests/10-report.xml
+++ b/tests/10-report.xml
@@ -2,7 +2,7 @@
 <testsuites>
 	<testsuite tests="2" failures="0" time="0.400" name="package1/foo">
 		<properties>
-			<property name="go.version" value="go1.4.2"></property>
+			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="10.0"></property>
 		</properties>
 		<testcase classname="foo" name="TestA" time="0.100"></testcase>
@@ -10,7 +10,7 @@
 	</testsuite>
 	<testsuite tests="1" failures="0" time="4.200" name="package2/bar">
 		<properties>
-			<property name="go.version" value="go1.4.2"></property>
+			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="99.8"></property>
 		</properties>
 		<testcase classname="bar" name="TestC" time="4.200"></testcase>


### PR DESCRIPTION
When `go test` is run on multiple packages and with coverage collection
enabled, it appends coverage information to the final result line for
each package.

With this change, properly handle this additional information and add it
into the JUnit XML report as a property of the test suite.