### PR TITLE
Add support for Go 1.5 test results

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -329,6 +329,32 @@ var testCases = []TestCase{
 			},
 		},
 	},
+	{
+		name:       "11-go_1_5.txt",
+		reportName: "11-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name: "package/name",
+					Time: 50,
+					Tests: []*parser.Test{
+						{
+							Name:   "TestOne",
+							Time:   20,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestTwo",
+							Time:   30,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestParser(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -78,9 +78,9 @@ func Parse(r io.Reader, pkgName string) (*Report, error) {
 
 		if strings.HasPrefix(line, "=== RUN ") {
 			// new test
-			cur = line[8:]
+			cur = strings.TrimSpace(line[8:])
 			tests = append(tests, &Test{
-				Name:   line[8:],
+				Name:   cur,
 				Result: FAIL,
 				Output: make([]string, 0),
 			})

--- a/tests/11-go_1_5.txt
+++ b/tests/11-go_1_5.txt
@@ -1,0 +1,6 @@
+=== RUN   TestOne
+--- PASS: TestOne (0.02s)
+=== RUN   TestTwo
+--- PASS: TestTwo (0.03s)
+PASS
+ok  	package/name	0.050s

--- a/tests/11-report.xml
+++ b/tests/11-report.xml
@@ -2,7 +2,7 @@
 <testsuites>
 	<testsuite tests="2" failures="0" time="0.050" name="package/name">
 		<properties>
-			<property name="go.version" value="go1.5"></property>
+			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="name" name="TestOne" time="0.020"></testcase>
 		<testcase classname="name" name="TestTwo" time="0.030"></testcase>

--- a/tests/11-report.xml
+++ b/tests/11-report.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="2" failures="0" time="0.050" name="package/name">
+		<properties>
+			<property name="go.version" value="go1.5"></property>
+		</properties>
+		<testcase classname="name" name="TestOne" time="0.020"></testcase>
+		<testcase classname="name" name="TestTwo" time="0.030"></testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
An alternate approach that does not involve regular expressions.

Fixes #15

Similar to #16 but does not use regular expressions nor change the import path.