### PR TITLE
Fix handling for failed to build packages

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -3,13 +3,12 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"github.com/jstemmer/go-junit-report/parser"
 	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
 	"testing"
-
-	"github.com/jstemmer/go-junit-report/parser"
 )
 
 type TestCase struct {
@@ -349,6 +348,26 @@ var testCases = []TestCase{
 							Time:   30,
 							Result: parser.PASS,
 							Output: []string{},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name:       "12-failed.txt",
+		reportName: "12-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name: "package/flailing",
+					Time: 0,
+					Tests: []*parser.Test{
+						{
+							Name:   "Build",
+							Time:   0,
+							Result: parser.FAIL,
+							Output: []string{"build failed"},
 						},
 					},
 				},

--- a/tests/12-failed.txt
+++ b/tests/12-failed.txt
@@ -1,0 +1,2 @@
+?   	package/missing [no test files]
+FAIL   	package/flailing [build failed]

--- a/tests/12-report.xml
+++ b/tests/12-report.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="1" failures="1" time="0.000" name="package/flailing">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="flailing" name="Build" time="0.000">
+			<failure message="Failed" type="">build failed</failure>
+		</testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
We found that when the code completely fails to build, we don't get any sort of test failure.

This is a bit subjective: Whether the failing build should be considered a test failure or not is down to consumption. We don't want it to look like everything was okay when it wasn't, but it's not good to lie about an actual test failure.

So: Take it or leave it at your discretion.