### PR TITLE
Add support for gocheck verbose test output.

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -355,6 +355,33 @@ var testCases = []TestCase{
 			},
 		},
 	},
+	{
+		name:       "12-gocheck.v.txt",
+		reportName: "12-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name: "package/name",
+					Time: 50,
+					Tests: []*parser.Test{
+						{
+							Name:   "TestOne",
+							Time:   20,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestTwo",
+							Time:   30,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+					},
+					CoveragePct: "13.37",
+				},
+			},
+		},
+	},
 }
 
 func TestParser(t *testing.T) {

--- a/tests/12-gocheck.v.txt
+++ b/tests/12-gocheck.v.txt
@@ -1,0 +1,6 @@
+PASS: one_test.go:239: TestSuite.TestOne	0.020s
+PASS: two_test.go:226: TestSuite.TestTwo	0.030s
+OK: 2 passed
+PASS
+coverage: 13.37% of statements
+ok  	package/name	0.050s

--- a/tests/12-report.xml
+++ b/tests/12-report.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="2" failures="0" time="0.050" name="package/name">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+			<property name="coverage.statements.pct" value="13.37"></property>
+		</properties>
+		<testcase classname="name" name="TestOne" time="0.020"></testcase>
+		<testcase classname="name" name="TestTwo" time="0.030"></testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
Running "go test -gocheck.v | go-junit-report > report.xml" will produce full report of tests in gocheck testsuites.
