### PR TITLE
refactored to allow for nested test-suites

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -25,22 +25,27 @@ var testCases = []TestCase{
 		name:       "01-pass.txt",
 		reportName: "01-report.xml",
 		report: &parser.Report{
-			Packages: []parser.Package{
+			Packages: []*parser.Package{
 				{
-					Name: "package/name",
-					Time: 160,
-					Tests: []*parser.Test{
+					Name: "package",
+					Children: []*parser.Package{
 						{
-							Name:   "TestZ",
-							Time:   60,
-							Result: parser.PASS,
-							Output: []string{},
-						},
-						{
-							Name:   "TestA",
-							Time:   100,
-							Result: parser.PASS,
-							Output: []string{},
+							Name: "package/name",
+							Time: 160,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestZ",
+									Time:   60,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+								{
+									Name:   "TestA",
+									Time:   100,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+							},
 						},
 					},
 				},
@@ -51,27 +56,32 @@ var testCases = []TestCase{
 		name:       "02-fail.txt",
 		reportName: "02-report.xml",
 		report: &parser.Report{
-			Packages: []parser.Package{
+			Packages: []*parser.Package{
 				{
-					Name: "package/name",
-					Time: 151,
-					Tests: []*parser.Test{
+					Name: "package",
+					Children: []*parser.Package{
 						{
-							Name:   "TestOne",
-							Time:   20,
-							Result: parser.FAIL,
-							Output: []string{
-								"file_test.go:11: Error message",
-								"file_test.go:11: Longer",
-								"\terror",
-								"\tmessage.",
+							Name: "package/name",
+							Time: 151,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestOne",
+									Time:   20,
+									Result: parser.FAIL,
+									Output: []string{
+										"file_test.go:11: Error message",
+										"file_test.go:11: Longer",
+										"\terror",
+										"\tmessage.",
+									},
+								},
+								{
+									Name:   "TestTwo",
+									Time:   130,
+									Result: parser.PASS,
+									Output: []string{},
+								},
 							},
-						},
-						{
-							Name:   "TestTwo",
-							Time:   130,
-							Result: parser.PASS,
-							Output: []string{},
 						},
 					},
 				},
@@ -82,24 +92,29 @@ var testCases = []TestCase{
 		name:       "03-skip.txt",
 		reportName: "03-report.xml",
 		report: &parser.Report{
-			Packages: []parser.Package{
+			Packages: []*parser.Package{
 				{
-					Name: "package/name",
-					Time: 150,
-					Tests: []*parser.Test{
+					Name: "package",
+					Children: []*parser.Package{
 						{
-							Name:   "TestOne",
-							Time:   20,
-							Result: parser.SKIP,
-							Output: []string{
-								"file_test.go:11: Skip message",
+							Name: "package/name",
+							Time: 150,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestOne",
+									Time:   20,
+									Result: parser.SKIP,
+									Output: []string{
+										"file_test.go:11: Skip message",
+									},
+								},
+								{
+									Name:   "TestTwo",
+									Time:   130,
+									Result: parser.PASS,
+									Output: []string{},
+								},
 							},
-						},
-						{
-							Name:   "TestTwo",
-							Time:   130,
-							Result: parser.PASS,
-							Output: []string{},
 						},
 					},
 				},
@@ -110,22 +125,27 @@ var testCases = []TestCase{
 		name:       "04-go_1_4.txt",
 		reportName: "04-report.xml",
 		report: &parser.Report{
-			Packages: []parser.Package{
+			Packages: []*parser.Package{
 				{
-					Name: "package/name",
-					Time: 160,
-					Tests: []*parser.Test{
+					Name: "package",
+					Children: []*parser.Package{
 						{
-							Name:   "TestOne",
-							Time:   60,
-							Result: parser.PASS,
-							Output: []string{},
-						},
-						{
-							Name:   "TestTwo",
-							Time:   100,
-							Result: parser.PASS,
-							Output: []string{},
+							Name: "package/name",
+							Time: 160,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestOne",
+									Time:   60,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+								{
+									Name:   "TestTwo",
+									Time:   100,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+							},
 						},
 					},
 				},
@@ -136,22 +156,27 @@ var testCases = []TestCase{
 		name:       "05-no_xml_header.txt",
 		reportName: "05-report.xml",
 		report: &parser.Report{
-			Packages: []parser.Package{
+			Packages: []*parser.Package{
 				{
-					Name: "package/name",
-					Time: 160,
-					Tests: []*parser.Test{
+					Name: "package",
+					Children: []*parser.Package{
 						{
-							Name:   "TestOne",
-							Time:   60,
-							Result: parser.PASS,
-							Output: []string{},
-						},
-						{
-							Name:   "TestTwo",
-							Time:   100,
-							Result: parser.PASS,
-							Output: []string{},
+							Name: "package/name",
+							Time: 160,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestOne",
+									Time:   60,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+								{
+									Name:   "TestTwo",
+									Time:   100,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+							},
 						},
 					},
 				},
@@ -163,45 +188,50 @@ var testCases = []TestCase{
 		name:       "06-mixed.txt",
 		reportName: "06-report.xml",
 		report: &parser.Report{
-			Packages: []parser.Package{
+			Packages: []*parser.Package{
 				{
-					Name: "package/name1",
-					Time: 160,
-					Tests: []*parser.Test{
+					Name: "package",
+					Children: []*parser.Package{
 						{
-							Name:   "TestOne",
-							Time:   60,
-							Result: parser.PASS,
-							Output: []string{},
-						},
-						{
-							Name:   "TestTwo",
-							Time:   100,
-							Result: parser.PASS,
-							Output: []string{},
-						},
-					},
-				},
-				{
-					Name: "package/name2",
-					Time: 151,
-					Tests: []*parser.Test{
-						{
-							Name:   "TestOne",
-							Time:   20,
-							Result: parser.FAIL,
-							Output: []string{
-								"file_test.go:11: Error message",
-								"file_test.go:11: Longer",
-								"\terror",
-								"\tmessage.",
+							Name: "package/name1",
+							Time: 160,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestOne",
+									Time:   60,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+								{
+									Name:   "TestTwo",
+									Time:   100,
+									Result: parser.PASS,
+									Output: []string{},
+								},
 							},
 						},
 						{
-							Name:   "TestTwo",
-							Time:   130,
-							Result: parser.PASS,
-							Output: []string{},
+							Name: "package/name2",
+							Time: 151,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestOne",
+									Time:   20,
+									Result: parser.FAIL,
+									Output: []string{
+										"file_test.go:11: Error message",
+										"file_test.go:11: Longer",
+										"\terror",
+										"\tmessage.",
+									},
+								},
+								{
+									Name:   "TestTwo",
+									Time:   130,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+							},
 						},
 					},
 				},
@@ -213,8 +243,9 @@ var testCases = []TestCase{
 		name:       "07-compiled_test.txt",
 		reportName: "07-report.xml",
 		report: &parser.Report{
-			Packages: []parser.Package{
+			Packages: []*parser.Package{
 				{
+
 					Name: "test/package",
 					Time: 160,
 					Tests: []*parser.Test{
@@ -240,22 +271,32 @@ var testCases = []TestCase{
 		name:       "08-parallel.txt",
 		reportName: "08-report.xml",
 		report: &parser.Report{
-			Packages: []parser.Package{
+			Packages: []*parser.Package{
 				{
-					Name: "github.com/dmitris/test-go-junit-report",
-					Time: 440,
-					Tests: []*parser.Test{
+					Name: "github.com",
+					Children: []*parser.Package{
 						{
-							Name:   "TestDoFoo",
-							Time:   270,
-							Result: parser.PASS,
-							Output: []string{"cov_test.go:10: DoFoo log 1", "cov_test.go:10: DoFoo log 2"},
-						},
-						{
-							Name:   "TestDoFoo2",
-							Time:   160,
-							Result: parser.PASS,
-							Output: []string{"cov_test.go:21: DoFoo2 log 1", "cov_test.go:21: DoFoo2 log 2"},
+							Name: "github.com/dmitris",
+							Children: []*parser.Package{
+								{
+									Name: "github.com/dmitris/test-go-junit-report",
+									Time: 440,
+									Tests: []*parser.Test{
+										{
+											Name:   "TestDoFoo",
+											Time:   270,
+											Result: parser.PASS,
+											Output: []string{"cov_test.go:10: DoFoo log 1", "cov_test.go:10: DoFoo log 2"},
+										},
+										{
+											Name:   "TestDoFoo2",
+											Time:   160,
+											Result: parser.PASS,
+											Output: []string{"cov_test.go:21: DoFoo2 log 1", "cov_test.go:21: DoFoo2 log 2"},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -266,25 +307,30 @@ var testCases = []TestCase{
 		name:       "09-coverage.txt",
 		reportName: "09-report.xml",
 		report: &parser.Report{
-			Packages: []parser.Package{
+			Packages: []*parser.Package{
 				{
-					Name: "package/name",
-					Time: 160,
-					Tests: []*parser.Test{
+					Name: "package",
+					Children: []*parser.Package{
 						{
-							Name:   "TestZ",
-							Time:   60,
-							Result: parser.PASS,
-							Output: []string{},
-						},
-						{
-							Name:   "TestA",
-							Time:   100,
-							Result: parser.PASS,
-							Output: []string{},
+							Name: "package/name",
+							Time: 160,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestZ",
+									Time:   60,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+								{
+									Name:   "TestA",
+									Time:   100,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+							},
+							CoveragePct: "13.37",
 						},
 					},
-					CoveragePct: "13.37",
 				},
 			},
 		},
@@ -293,38 +339,48 @@ var testCases = []TestCase{
 		name:       "10-multipkg-coverage.txt",
 		reportName: "10-report.xml",
 		report: &parser.Report{
-			Packages: []parser.Package{
+			Packages: []*parser.Package{
 				{
-					Name: "package1/foo",
-					Time: 400,
-					Tests: []*parser.Test{
+					Name: "package1",
+					Children: []*parser.Package{
 						{
-							Name:   "TestA",
-							Time:   100,
-							Result: parser.PASS,
-							Output: []string{},
-						},
-						{
-							Name:   "TestB",
-							Time:   300,
-							Result: parser.PASS,
-							Output: []string{},
+							Name: "package1/foo",
+							Time: 400,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestA",
+									Time:   100,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+								{
+									Name:   "TestB",
+									Time:   300,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+							},
+							CoveragePct: "10.0",
 						},
 					},
-					CoveragePct: "10.0",
 				},
 				{
-					Name: "package2/bar",
-					Time: 4200,
-					Tests: []*parser.Test{
+					Name: "package2",
+					Children: []*parser.Package{
 						{
-							Name:   "TestC",
-							Time:   4200,
-							Result: parser.PASS,
-							Output: []string{},
+							Name: "package2/bar",
+							Time: 4200,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestC",
+									Time:   4200,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+							},
+							CoveragePct: "99.8",
 						},
 					},
-					CoveragePct: "99.8",
 				},
 			},
 		},
@@ -333,22 +389,88 @@ var testCases = []TestCase{
 		name:       "11-go_1_5.txt",
 		reportName: "11-report.xml",
 		report: &parser.Report{
-			Packages: []parser.Package{
+			Packages: []*parser.Package{
 				{
-					Name: "package/name",
-					Time: 50,
-					Tests: []*parser.Test{
+					Name: "package",
+					Children: []*parser.Package{
 						{
-							Name:   "TestOne",
-							Time:   20,
-							Result: parser.PASS,
-							Output: []string{},
+							Name: "package/name",
+							Time: 50,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestOne",
+									Time:   20,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+								{
+									Name:   "TestTwo",
+									Time:   30,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name:       "12-nested.txt",
+		reportName: "12-report.xml",
+		report: &parser.Report{
+			Packages: []*parser.Package{
+				{
+					Name: "package1",
+					Time: 0,
+					Children: []*parser.Package{
+						{
+							Name: "package1/foo",
+							Time: 400,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestA",
+									Time:   100,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+								{
+									Name:   "TestB",
+									Time:   300,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+							},
+							CoveragePct: "10.0",
 						},
 						{
-							Name:   "TestTwo",
-							Time:   30,
-							Result: parser.PASS,
-							Output: []string{},
+							Name: "package1/bar",
+							Time: 4200,
+							Tests: []*parser.Test{
+								{
+									Name:   "TestC",
+									Time:   4200,
+									Result: parser.PASS,
+									Output: []string{},
+								},
+							},
+							CoveragePct: "99.8",
+							Children: []*parser.Package{
+								{
+									Name: "package1/bar/baz",
+									Time: 8400,
+									Tests: []*parser.Test{
+										{
+											Name:   "TestD",
+											Time:   8400,
+											Result: parser.PASS,
+											Output: []string{},
+										},
+									},
+									CoveragePct: "20.0",
+								},
+							},
 						},
 					},
 				},
@@ -377,49 +499,64 @@ func TestParser(t *testing.T) {
 
 		expected := testCase.report
 		if len(report.Packages) != len(expected.Packages) {
+			fmt.Printf("%s", report)
 			t.Fatalf("Report packages == %d, want %d", len(report.Packages), len(expected.Packages))
 		}
 
 		for i, pkg := range report.Packages {
 			expPkg := expected.Packages[i]
 
-			if pkg.Name != expPkg.Name {
-				t.Errorf("Package.Name == %s, want %s", pkg.Name, expPkg.Name)
-			}
-
-			if pkg.Time != expPkg.Time {
-				t.Errorf("Package.Time == %d, want %d", pkg.Time, expPkg.Time)
-			}
-
-			if len(pkg.Tests) != len(expPkg.Tests) {
-				t.Fatalf("Package Tests == %d, want %d", len(pkg.Tests), len(expPkg.Tests))
-			}
-
-			for j, test := range pkg.Tests {
-				expTest := expPkg.Tests[j]
-
-				if test.Name != expTest.Name {
-					t.Errorf("Test.Name == %s, want %s", test.Name, expTest.Name)
-				}
-
-				if test.Time != expTest.Time {
-					t.Errorf("Test.Time == %d, want %d", test.Time, expTest.Time)
-				}
-
-				if test.Result != expTest.Result {
-					t.Errorf("Test.Result == %d, want %d", test.Result, expTest.Result)
-				}
-
-				testOutput := strings.Join(test.Output, "\n")
-				expTestOutput := strings.Join(expTest.Output, "\n")
-				if testOutput != expTestOutput {
-					t.Errorf("Test.Output ==\n%s\n, want\n%s", testOutput, expTestOutput)
-				}
-			}
-			if pkg.CoveragePct != expPkg.CoveragePct {
-				t.Errorf("Package.CoveragePct == %s, want %s", pkg.CoveragePct, expPkg.CoveragePct)
-			}
+			checkPackages(expPkg, pkg, t)
 		}
+	}
+}
+
+func checkPackages(expPkg, pkg *parser.Package, t *testing.T) {
+	if pkg.Name != expPkg.Name {
+		t.Errorf("Package.Name == %s, want %s", pkg.Name, expPkg.Name)
+	}
+
+	if pkg.Time != expPkg.Time {
+		t.Errorf("Package.Time == %d, want %d", pkg.Time, expPkg.Time)
+	}
+
+	if len(pkg.Tests) != len(expPkg.Tests) {
+		t.Fatalf("Package Tests == %d, want %d", len(pkg.Tests), len(expPkg.Tests))
+	}
+
+	if len(pkg.Children) != len(expPkg.Children) {
+		t.Fatalf("Package Children == %d, want %d", len(pkg.Children), len(expPkg.Children))
+	}
+
+	for j, test := range pkg.Tests {
+		expTest := expPkg.Tests[j]
+
+		if test.Name != expTest.Name {
+			t.Errorf("Test.Name == %s, want %s", test.Name, expTest.Name)
+		}
+
+		if test.Time != expTest.Time {
+			t.Errorf("Test.Time == %d, want %d", test.Time, expTest.Time)
+		}
+
+		if test.Result != expTest.Result {
+			t.Errorf("Test.Result == %d, want %d", test.Result, expTest.Result)
+		}
+
+		testOutput := strings.Join(test.Output, "\n")
+		expTestOutput := strings.Join(expTest.Output, "\n")
+		if testOutput != expTestOutput {
+			t.Errorf("Test.Output ==\n%s\n, want\n%s", testOutput, expTestOutput)
+		}
+	}
+	if pkg.CoveragePct != expPkg.CoveragePct {
+		t.Errorf("Package.CoveragePct == %s, want %s", pkg.CoveragePct, expPkg.CoveragePct)
+	}
+
+	for i, child := range pkg.Children {
+		expChild := expPkg.Children[i]
+
+		checkPackages(expChild, child, t)
 	}
 }
 

--- a/junit-formatter.go
+++ b/junit-formatter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/jstemmer/go-junit-report/parser"
@@ -27,6 +28,8 @@ type JUnitTestSuite struct {
 	Name       string          `xml:"name,attr"`
 	Properties []JUnitProperty `xml:"properties>property,omitempty"`
 	TestCases  []JUnitTestCase
+
+	Children []JUnitTestSuite
 }
 
 // JUnitTestCase is a single test case with its result.
@@ -64,52 +67,7 @@ func JUnitReportXML(report *parser.Report, noXMLHeader bool, w io.Writer) error 
 
 	// convert Report to JUnit test suites
 	for _, pkg := range report.Packages {
-		ts := JUnitTestSuite{
-			Tests:      len(pkg.Tests),
-			Failures:   0,
-			Time:       formatTime(pkg.Time),
-			Name:       pkg.Name,
-			Properties: []JUnitProperty{},
-			TestCases:  []JUnitTestCase{},
-		}
-
-		classname := pkg.Name
-		if idx := strings.LastIndex(classname, "/"); idx > -1 && idx < len(pkg.Name) {
-			classname = pkg.Name[idx+1:]
-		}
-
-		// properties
-		ts.Properties = append(ts.Properties, JUnitProperty{"go.version", runtime.Version()})
-		if pkg.CoveragePct != "" {
-			ts.Properties = append(ts.Properties, JUnitProperty{"coverage.statements.pct", pkg.CoveragePct})
-		}
-
-		// individual test cases
-		for _, test := range pkg.Tests {
-			testCase := JUnitTestCase{
-				Classname: classname,
-				Name:      test.Name,
-				Time:      formatTime(test.Time),
-				Failure:   nil,
-			}
-
-			if test.Result == parser.FAIL {
-				ts.Failures++
-				testCase.Failure = &JUnitFailure{
-					Message:  "Failed",
-					Type:     "",
-					Contents: strings.Join(test.Output, "\n"),
-				}
-			}
-
-			if test.Result == parser.SKIP {
-				testCase.SkipMessage = &JUnitSkipMessage{strings.Join(test.Output, "\n")}
-			}
-
-			ts.TestCases = append(ts.TestCases, testCase)
-		}
-
-		suites.Suites = append(suites.Suites, ts)
+		suites.Suites = append(suites.Suites, convertToExternalRepresentation(pkg))
 	}
 
 	// to xml
@@ -131,6 +89,67 @@ func JUnitReportXML(report *parser.Report, noXMLHeader bool, w io.Writer) error 
 	return nil
 }
 
+func convertToExternalRepresentation(input *parser.Package) JUnitTestSuite {
+	ts := JUnitTestSuite{
+		Tests:      len(input.Tests),
+		Failures:   0,
+		Time:       formatTime(input.Time),
+		Name:       input.Name,
+		Properties: []JUnitProperty{},
+		TestCases:  []JUnitTestCase{},
+		Children:   []JUnitTestSuite{},
+	}
+
+	classname := input.Name
+	if idx := strings.LastIndex(classname, "/"); idx > -1 && idx < len(input.Name) {
+		classname = input.Name[idx+1:]
+	}
+
+	// properties
+	ts.Properties = append(ts.Properties, JUnitProperty{"go.version", runtime.Version()})
+	if input.CoveragePct != "" {
+		ts.Properties = append(ts.Properties, JUnitProperty{"coverage.statements.pct", input.CoveragePct})
+	}
+
+	// individual test cases
+	for _, test := range input.Tests {
+		testCase := JUnitTestCase{
+			Classname: classname,
+			Name:      test.Name,
+			Time:      formatTime(test.Time),
+			Failure:   nil,
+		}
+
+		if test.Result == parser.FAIL {
+			ts.Failures++
+			testCase.Failure = &JUnitFailure{
+				Message:  "Failed",
+				Type:     "",
+				Contents: strings.Join(test.Output, "\n"),
+			}
+		}
+
+		if test.Result == parser.SKIP {
+			testCase.SkipMessage = &JUnitSkipMessage{strings.Join(test.Output, "\n")}
+		}
+
+		ts.TestCases = append(ts.TestCases, testCase)
+	}
+
+	// child packages
+	for _, child := range input.Children {
+		ts.Children = append(ts.Children, convertToExternalRepresentation(child))
+	}
+
+	// update metrics from children
+	for _, child := range ts.Children {
+		ts.Tests = ts.Tests + child.Tests
+		ts.Failures = ts.Failures + child.Failures
+		ts.Time = strconv.FormatFloat(atof(ts.Time)+atof(child.Time), 'f', 3, 64)
+	}
+	return ts
+}
+
 func countFailures(tests []parser.Test) (result int) {
 	for _, test := range tests {
 		if test.Result == parser.FAIL {
@@ -142,4 +161,11 @@ func countFailures(tests []parser.Test) (result int) {
 
 func formatTime(time int) string {
 	return fmt.Sprintf("%.3f", float64(time)/1000.0)
+}
+
+// atof converts a string representing a float64 to the float
+func atof(value string) float64 {
+	// we discard the error as we know our time values are floats
+	number, _ := strconv.ParseFloat(value, 64)
+	return number
 }

--- a/tests/01-report.xml
+++ b/tests/01-report.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+	<testsuite tests="2" failures="0" time="0.160" name="package">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestZ" time="0.060"></testcase>
-		<testcase classname="name" name="TestA" time="0.100"></testcase>
+		<testsuite tests="2" failures="0" time="0.160" name="package/name">
+			<properties>
+				<property name="go.version" value="1.0"></property>
+			</properties>
+			<testcase classname="name" name="TestZ" time="0.060"></testcase>
+			<testcase classname="name" name="TestA" time="0.100"></testcase>
+		</testsuite>
 	</testsuite>
 </testsuites>

--- a/tests/02-report.xml
+++ b/tests/02-report.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="1" time="0.151" name="package/name">
+	<testsuite tests="2" failures="1" time="0.151" name="package">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestOne" time="0.020">
-			<failure message="Failed" type="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;&#x9;error&#xA;&#x9;message.</failure>
-		</testcase>
-		<testcase classname="name" name="TestTwo" time="0.130"></testcase>
+		<testsuite tests="2" failures="1" time="0.151" name="package/name">
+			<properties>
+				<property name="go.version" value="1.0"></property>
+			</properties>
+			<testcase classname="name" name="TestOne" time="0.020">
+				<failure message="Failed" type="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;&#x9;error&#xA;&#x9;message.</failure>
+			</testcase>
+			<testcase classname="name" name="TestTwo" time="0.130"></testcase>
+		</testsuite>
 	</testsuite>
 </testsuites>

--- a/tests/03-report.xml
+++ b/tests/03-report.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.150" name="package/name">
+	<testsuite tests="2" failures="0" time="0.150" name="package">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestOne" time="0.020">
-			<skipped message="file_test.go:11: Skip message"></skipped>
-		</testcase>
-		<testcase classname="name" name="TestTwo" time="0.130"></testcase>
+		<testsuite tests="2" failures="0" time="0.150" name="package/name">
+			<properties>
+				<property name="go.version" value="1.0"></property>
+			</properties>
+			<testcase classname="name" name="TestOne" time="0.020">
+				<skipped message="file_test.go:11: Skip message"></skipped>
+			</testcase>
+			<testcase classname="name" name="TestTwo" time="0.130"></testcase>
+		</testsuite>
 	</testsuite>
 </testsuites>

--- a/tests/04-report.xml
+++ b/tests/04-report.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+	<testsuite tests="2" failures="0" time="0.160" name="package">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestOne" time="0.060"></testcase>
-		<testcase classname="name" name="TestTwo" time="0.100"></testcase>
+		<testsuite tests="2" failures="0" time="0.160" name="package/name">
+			<properties>
+				<property name="go.version" value="1.0"></property>
+			</properties>
+			<testcase classname="name" name="TestOne" time="0.060"></testcase>
+			<testcase classname="name" name="TestTwo" time="0.100"></testcase>
+		</testsuite>
 	</testsuite>
 </testsuites>

--- a/tests/05-report.xml
+++ b/tests/05-report.xml
@@ -1,9 +1,14 @@
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+	<testsuite tests="2" failures="0" time="0.160" name="package">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestOne" time="0.060"></testcase>
-		<testcase classname="name" name="TestTwo" time="0.100"></testcase>
+		<testsuite tests="2" failures="0" time="0.160" name="package/name">
+			<properties>
+				<property name="go.version" value="1.0"></property>
+			</properties>
+			<testcase classname="name" name="TestOne" time="0.060"></testcase>
+			<testcase classname="name" name="TestTwo" time="0.100"></testcase>
+		</testsuite>
 	</testsuite>
 </testsuites>

--- a/tests/06-report.xml
+++ b/tests/06-report.xml
@@ -1,18 +1,23 @@
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="package/name1">
+	<testsuite tests="4" failures="1" time="0.311" name="package">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name1" name="TestOne" time="0.060"></testcase>
-		<testcase classname="name1" name="TestTwo" time="0.100"></testcase>
-	</testsuite>
-	<testsuite tests="2" failures="1" time="0.151" name="package/name2">
-		<properties>
-			<property name="go.version" value="1.0"></property>
-		</properties>
-		<testcase classname="name2" name="TestOne" time="0.020">
-			<failure message="Failed" type="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;&#x9;error&#xA;&#x9;message.</failure>
-		</testcase>
-		<testcase classname="name2" name="TestTwo" time="0.130"></testcase>
+		<testsuite tests="2" failures="0" time="0.160" name="package/name1">
+			<properties>
+				<property name="go.version" value="1.0"></property>
+			</properties>
+			<testcase classname="name1" name="TestOne" time="0.060"></testcase>
+			<testcase classname="name1" name="TestTwo" time="0.100"></testcase>
+		</testsuite>
+		<testsuite tests="2" failures="1" time="0.151" name="package/name2">
+			<properties>
+				<property name="go.version" value="1.0"></property>
+			</properties>
+			<testcase classname="name2" name="TestOne" time="0.020">
+				<failure message="Failed" type="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;&#x9;error&#xA;&#x9;message.</failure>
+			</testcase>
+			<testcase classname="name2" name="TestTwo" time="0.130"></testcase>
+		</testsuite>
 	</testsuite>
 </testsuites>

--- a/tests/08-report.xml
+++ b/tests/08-report.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.440" name="github.com/dmitris/test-go-junit-report">
+	<testsuite tests="2" failures="0" time="0.440" name="github.com">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="test-go-junit-report" name="TestDoFoo" time="0.270"></testcase>
-		<testcase classname="test-go-junit-report" name="TestDoFoo2" time="0.160"></testcase>
+		<testsuite tests="2" failures="0" time="0.440" name="github.com/dmitris">
+			<properties>
+				<property name="go.version" value="1.0"></property>
+			</properties>
+			<testsuite tests="2" failures="0" time="0.440" name="github.com/dmitris/test-go-junit-report">
+				<properties>
+					<property name="go.version" value="1.0"></property>
+				</properties>
+				<testcase classname="test-go-junit-report" name="TestDoFoo" time="0.270"></testcase>
+				<testcase classname="test-go-junit-report" name="TestDoFoo2" time="0.160"></testcase>
+			</testsuite>
+		</testsuite>
 	</testsuite>
 </testsuites>

--- a/tests/09-report.xml
+++ b/tests/09-report.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+	<testsuite tests="2" failures="0" time="0.160" name="package">
 		<properties>
 			<property name="go.version" value="1.0"></property>
-			<property name="coverage.statements.pct" value="13.37"></property>
 		</properties>
-		<testcase classname="name" name="TestZ" time="0.060"></testcase>
-		<testcase classname="name" name="TestA" time="0.100"></testcase>
+		<testsuite tests="2" failures="0" time="0.160" name="package/name">
+			<properties>
+				<property name="go.version" value="1.0"></property>
+				<property name="coverage.statements.pct" value="13.37"></property>
+			</properties>
+			<testcase classname="name" name="TestZ" time="0.060"></testcase>
+			<testcase classname="name" name="TestA" time="0.100"></testcase>
+		</testsuite>
 	</testsuite>
 </testsuites>

--- a/tests/11-report.xml
+++ b/tests/11-report.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.050" name="package/name">
+	<testsuite tests="2" failures="0" time="0.050" name="package">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestOne" time="0.020"></testcase>
-		<testcase classname="name" name="TestTwo" time="0.030"></testcase>
+		<testsuite tests="2" failures="0" time="0.050" name="package/name">
+			<properties>
+				<property name="go.version" value="1.0"></property>
+			</properties>
+			<testcase classname="name" name="TestOne" time="0.020"></testcase>
+			<testcase classname="name" name="TestTwo" time="0.030"></testcase>
+		</testsuite>
 	</testsuite>
 </testsuites>

--- a/tests/12-nested.txt
+++ b/tests/12-nested.txt
@@ -1,0 +1,17 @@
+=== RUN TestA
+--- PASS: TestA (0.10 seconds)
+=== RUN TestB
+--- PASS: TestB (0.30 seconds)
+PASS
+coverage: 10% of statements
+ok  	package1/foo 0.400s  coverage: 10.0% of statements
+=== RUN TestC
+--- PASS: TestC (4.20 seconds)
+PASS
+coverage: 99.8% of statements
+ok  	package1/bar 4.200s  coverage: 99.8% of statements
+=== RUN TestD
+--- PASS: TestD (8.40 seconds)
+PASS
+coverage: 20.0% of statements
+ok  	package1/bar/baz 8.400s  coverage: 20.0% of statements

--- a/tests/12-report.xml
+++ b/tests/12-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.400" name="package1">
+	<testsuite tests="4" failures="0" time="13.000" name="package1">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
@@ -12,17 +12,19 @@
 			<testcase classname="foo" name="TestA" time="0.100"></testcase>
 			<testcase classname="foo" name="TestB" time="0.300"></testcase>
 		</testsuite>
-	</testsuite>
-	<testsuite tests="1" failures="0" time="4.200" name="package2">
-		<properties>
-			<property name="go.version" value="1.0"></property>
-		</properties>
-		<testsuite tests="1" failures="0" time="4.200" name="package2/bar">
+		<testsuite tests="2" failures="0" time="12.600" name="package1/bar">
 			<properties>
 				<property name="go.version" value="1.0"></property>
 				<property name="coverage.statements.pct" value="99.8"></property>
 			</properties>
 			<testcase classname="bar" name="TestC" time="4.200"></testcase>
+			<testsuite tests="1" failures="0" time="8.400" name="package1/bar/baz">
+				<properties>
+					<property name="go.version" value="1.0"></property>
+					<property name="coverage.statements.pct" value="20.0"></property>
+				</properties>
+				<testcase classname="baz" name="TestD" time="8.400"></testcase>
+			</testsuite>
 		</testsuite>
 	</testsuite>
 </testsuites>


### PR DESCRIPTION
In order to get more value out of a tool like this, it is useful to have nested test suites. I've refactored the parser and formatter code so that they create nested output XML that follows package boundaries.

Fixes https://github.com/jstemmer/go-junit-report/issues/24