### PR TITLE
repackaged formatter

### DIFF
--- a/formatter/junit-formatter.go
+++ b/formatter/junit-formatter.go
@@ -1,4 +1,4 @@
-package main
+package formatter
 
 import (
 	"bufio"

--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jstemmer/go-junit-report/formatter"
 	"github.com/jstemmer/go-junit-report/parser"
 )
 
@@ -31,7 +32,7 @@ func main() {
 	}
 
 	// Write xml
-	err = JUnitReportXML(report, noXMLHeader, os.Stdout)
+	err = formatter.JUnitReportXML(report, noXMLHeader, os.Stdout)
 	if err != nil {
 		fmt.Printf("Error writing XML: %s\n", err)
 		os.Exit(1)

--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jstemmer/go-junit-report/formatter"
 	"github.com/jstemmer/go-junit-report/parser"
 )
 
@@ -432,7 +433,7 @@ func TestJUnitFormatter(t *testing.T) {
 
 		var junitReport bytes.Buffer
 
-		if err = JUnitReportXML(testCase.report, testCase.noXMLHeader, &junitReport); err != nil {
+		if err = formatter.JUnitReportXML(testCase.report, testCase.noXMLHeader, &junitReport); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
This change repackages the formatter code into its' own package, `formatter`, so that other projects can import it. It seems that it is disallowed to import a `main`. 