### PR TITLE
traverse the find list backwards which allows multiple tests with the same name

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -155,7 +155,7 @@ func parseTime(time string) int {
 }
 
 func findTest(tests []*Test, name string) *Test {
-	for i := 0; i < len(tests); i++ {
+	for i := len(tests) - 1; i >= 0; i-- {
 		if tests[i].Name == name {
 			return tests[i]
 		}


### PR DESCRIPTION
This breaks junit reports run with `go test -count n` where n is greater then 1. The junit xml spec does not state that tests must be unique.

Cc: @ixdy 
Ref: https://jira.atlassian.com/browse/BAM-14692
