### PR TITLE
Be more explicit about unexpected test formatting.

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -355,6 +355,32 @@ var testCases = []TestCase{
 			},
 		},
 	},
+	{
+		name:       "12-multiple.txt",
+		reportName: "12-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name: "package/name",
+					Time: 160,
+					Tests: []*parser.Test{
+						{
+							Name:   "TestA",
+							Time:   60,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+						{
+							Name:   "TestA",
+							Time:   100,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestParser(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"fmt"
+	"os"
 )
 
 // Result represents a test result.
@@ -55,12 +57,13 @@ func Parse(r io.Reader, pkgName string) (*Report, error) {
 
 	// keep track of tests we find
 	var tests []*Test
+	running := map[string][]*Test{}
+
+	// test for last seen result line
+	var lastResult *Test
 
 	// sum of tests' time, use this if current test has no result line (when it is compiled test)
 	testsTime := 0
-
-	// current test
-	var cur string
 
 	// coverage percentage report for current package
 	var coveragePct string
@@ -78,15 +81,26 @@ func Parse(r io.Reader, pkgName string) (*Report, error) {
 
 		if strings.HasPrefix(line, "=== RUN ") {
 			// new test
-			cur = strings.TrimSpace(line[8:])
-			tests = append(tests, &Test{
-				Name:   cur,
+			name := strings.TrimSpace(line[8:])
+			test := &Test{
+				Name:   name,
 				Result: FAIL,
 				Output: make([]string, 0),
-			})
+			}
+			if len(running[test.Name]) > 0 {
+				fmt.Fprintf(os.Stderr, "multiple tests with name %v running concurrently\n", test.Name)
+			}
+			running[test.Name] = append(running[test.Name], test)
+			tests = append(tests, test)
 		} else if matches := regexResult.FindStringSubmatch(line); len(matches) == 5 {
 			if matches[4] != "" {
 				coveragePct = matches[4]
+			}
+
+			if len(running) > 0 {
+				// `go test` should ensure that individual packets' tests' output are serialized,
+				// so there should be no running tests at package boundaries.
+				fmt.Fprintf(os.Stderr, "%v tests still running after package\n", len(running))
 			}
 
 			// all tests in this package are finished
@@ -97,39 +111,51 @@ func Parse(r io.Reader, pkgName string) (*Report, error) {
 				CoveragePct: coveragePct,
 			})
 
-			tests = make([]*Test, 0)
+			tests = nil
+			running = map[string][]*Test{}
 			coveragePct = ""
-			cur = ""
 			testsTime = 0
+			lastResult = nil
 		} else if matches := regexStatus.FindStringSubmatch(line); len(matches) == 4 {
-			cur = matches[2]
-			test := findTest(tests, cur)
-			if test == nil {
-				continue
+			name := matches[2]
+			if len(running[name]) == 0 {
+				fmt.Fprintf(os.Stderr, "Got test result for %v but no tests are running\n", name)
+				lastResult = &Test{
+					Name:   name,
+					Result: FAIL,
+					Output: make([]string, 0),
+				}
+			} else {
+				lastResult = running[name][0]
+				if len(running[name]) > 1 {
+					running[name] = running[name][1:]
+				} else {
+					delete(running, name)
+				}
 			}
 
 			// test status
 			if matches[1] == "PASS" {
-				test.Result = PASS
+				lastResult.Result = PASS
 			} else if matches[1] == "SKIP" {
-				test.Result = SKIP
+				lastResult.Result = SKIP
 			} else {
-				test.Result = FAIL
+				lastResult.Result = FAIL
 			}
 
-			test.Name = matches[2]
+			lastResult.Name = matches[2]
 			testTime := parseTime(matches[3]) * 10
-			test.Time = testTime
+			lastResult.Time = testTime
 			testsTime += testTime
+			lastResult = lastResult
 		} else if matches := regexCoverage.FindStringSubmatch(line); len(matches) == 2 {
 			coveragePct = matches[1]
 		} else if strings.HasPrefix(line, "\t") {
 			// test output
-			test := findTest(tests, cur)
-			if test == nil {
+			if lastResult == nil {
 				continue
 			}
-			test.Output = append(test.Output, line[1:])
+			lastResult.Output = append(lastResult.Output, line[1:])
 		}
 	}
 
@@ -152,15 +178,6 @@ func parseTime(time string) int {
 		return 0
 	}
 	return t
-}
-
-func findTest(tests []*Test, name string) *Test {
-	for i := 0; i < len(tests); i++ {
-		if tests[i].Name == name {
-			return tests[i]
-		}
-	}
-	return nil
 }
 
 // Failures counts the number of failed tests in this report

--- a/tests/12-multiple.txt
+++ b/tests/12-multiple.txt
@@ -1,0 +1,6 @@
+=== RUN TestA
+--- PASS: TestA (0.06 seconds)
+=== RUN TestA
+--- PASS: TestA (0.10 seconds)
+PASS
+ok  	package/name 0.160s

--- a/tests/12-report.xml
+++ b/tests/12-report.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="name" name="TestA" time="0.060"></testcase>
+		<testcase classname="name" name="TestA" time="0.100"></testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
Track running tests explicitly to make it clear when strange things occur in test output that may confuse the generated results. Implicitly also correctly handle multiple tests with the same name.
