### PR TITLE
Allow output to be written to file and input to go to stdout.

### DIFF
--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"io"
 
 	"github.com/jstemmer/go-junit-report/parser"
 )
@@ -12,26 +13,39 @@ var (
 	noXMLHeader bool
 	packageName string
 	setExitCode bool
+	outFile     string
 )
 
 func init() {
 	flag.BoolVar(&noXMLHeader, "no-xml-header", false, "do not print xml header")
 	flag.StringVar(&packageName, "package-name", "", "specify a package name (compiled test have no package name in output)")
 	flag.BoolVar(&setExitCode, "set-exit-code", false, "set exit code to 1 if tests failed")
+	flag.StringVar(&outFile, "out", "", "write output to file instead of stdout")
 }
 
 func main() {
 	flag.Parse()
 
+	var output io.Writer = os.Stdout
+	var input io.Reader = os.Stdin
+	if outFile != "" {
+		var err error
+		if output, err = os.Create(outFile); err != nil {
+			fmt.Printf("Error opening file: %s\n", err)
+			os.Exit(1)
+		}
+		input = io.TeeReader(os.Stdin, os.Stdout)
+	}
+
 	// Read input
-	report, err := parser.Parse(os.Stdin, packageName)
+	report, err := parser.Parse(input, packageName)
 	if err != nil {
 		fmt.Printf("Error reading input: %s\n", err)
 		os.Exit(1)
 	}
 
 	// Write xml
-	err = JUnitReportXML(report, noXMLHeader, os.Stdout)
+	err = JUnitReportXML(report, noXMLHeader, output)
 	if err != nil {
 		fmt.Printf("Error writing XML: %s\n", err)
 		os.Exit(1)

--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -14,6 +14,7 @@ var (
 	packageName string
 	setExitCode bool
 	outFile     string
+	outAppend   bool
 )
 
 func init() {
@@ -21,6 +22,7 @@ func init() {
 	flag.StringVar(&packageName, "package-name", "", "specify a package name (compiled test have no package name in output)")
 	flag.BoolVar(&setExitCode, "set-exit-code", false, "set exit code to 1 if tests failed")
 	flag.StringVar(&outFile, "out", "", "write output to file instead of stdout")
+	flag.BoolVar(&outAppend, "append", false, "append to output file instead of overwriting")
 }
 
 func main() {
@@ -30,7 +32,13 @@ func main() {
 	var input io.Reader = os.Stdin
 	if outFile != "" {
 		var err error
-		if output, err = os.Create(outFile); err != nil {
+		flags := os.O_WRONLY | os.O_CREATE
+		if outAppend {
+			flags |= os.O_APPEND
+		} else {
+			flags |= os.O_TRUNC
+		}
+		if output, err = os.OpenFile(outFile, flags, 0666); err != nil {
 			fmt.Printf("Error opening file: %s\n", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
I'd like to have the option to print the `go test` output as well as generate the report. This does that.

This functionality is important because the regular `go test` output includes more details.
