### PR TITLE
Fail package in case of build error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ go-junit-report reads the `go test` verbose output from standard in and writes
 junit compatible XML to standard out.
 
 ```bash
-go test -v | go-junit-report > report.xml
+go test -v 2>&1 | go-junit-report > report.xml
 ```
 
 [travis-badge]: https://travis-ci.org/jstemmer/go-junit-report.svg

--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -37,7 +37,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if setExitCode && report.Failed() {
+	if setExitCode && report.Failures() > 0 {
 		os.Exit(1)
 	}
 }

--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -37,7 +37,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if setExitCode && report.Failures() > 0 {
+	if setExitCode && report.Failed() {
 		os.Exit(1)
 	}
 }

--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -27,8 +27,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "package/name",
-					Time: 160,
+					Name:   "package/name",
+					Time:   160,
+					Result: parser.PASS,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestZ",
@@ -53,8 +54,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "package/name",
-					Time: 151,
+					Name:   "package/name",
+					Time:   151,
+					Result: parser.FAIL,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -84,8 +86,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "package/name",
-					Time: 150,
+					Name:   "package/name",
+					Time:   150,
+					Result: parser.PASS,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -112,8 +115,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "package/name",
-					Time: 160,
+					Name:   "package/name",
+					Time:   160,
+					Result: parser.PASS,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -138,8 +142,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "package/name",
-					Time: 160,
+					Name:   "package/name",
+					Time:   160,
+					Result: parser.PASS,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -165,8 +170,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "package/name1",
-					Time: 160,
+					Name:   "package/name1",
+					Time:   160,
+					Result: parser.PASS,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -183,8 +189,9 @@ var testCases = []TestCase{
 					},
 				},
 				{
-					Name: "package/name2",
-					Time: 151,
+					Name:   "package/name2",
+					Time:   151,
+					Result: parser.FAIL,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -215,8 +222,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "test/package",
-					Time: 160,
+					Name:   "test/package",
+					Time:   160,
+					Result: parser.PASS,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -242,8 +250,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "github.com/dmitris/test-go-junit-report",
-					Time: 440,
+					Name:   "github.com/dmitris/test-go-junit-report",
+					Time:   440,
+					Result: parser.PASS,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestDoFoo",
@@ -268,8 +277,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "package/name",
-					Time: 160,
+					Name:   "package/name",
+					Time:   160,
+					Result: parser.PASS,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestZ",
@@ -295,8 +305,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "package1/foo",
-					Time: 400,
+					Name:   "package1/foo",
+					Time:   400,
+					Result: parser.PASS,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestA",
@@ -314,8 +325,9 @@ var testCases = []TestCase{
 					CoveragePct: "10.0",
 				},
 				{
-					Name: "package2/bar",
-					Time: 4200,
+					Name:   "package2/bar",
+					Time:   4200,
+					Result: parser.PASS,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestC",
@@ -335,8 +347,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "package/name",
-					Time: 50,
+					Name:   "package/name",
+					Time:   50,
+					Result: parser.PASS,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -361,8 +374,9 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name: "package/name",
-					Time: 50,
+					Name:   "package/name",
+					Time:   50,
+					Result: parser.FAIL,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -483,6 +497,19 @@ var testCases = []TestCase{
 							},
 						},
 					},
+				},
+			},
+		},
+	},
+	{
+		name:       "13-syntax-error.txt",
+		reportName: "13-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name:   "package/name",
+					Result: parser.FAIL,
+					Tests:  []*parser.Test{},
 				},
 			},
 		},

--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -27,9 +27,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "package/name",
-					Time:   160,
-					Result: parser.PASS,
+					Name: "package/name",
+					Time: 160,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestZ",
@@ -54,9 +53,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "package/name",
-					Time:   151,
-					Result: parser.FAIL,
+					Name: "package/name",
+					Time: 151,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -86,9 +84,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "package/name",
-					Time:   150,
-					Result: parser.PASS,
+					Name: "package/name",
+					Time: 150,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -115,9 +112,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "package/name",
-					Time:   160,
-					Result: parser.PASS,
+					Name: "package/name",
+					Time: 160,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -142,9 +138,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "package/name",
-					Time:   160,
-					Result: parser.PASS,
+					Name: "package/name",
+					Time: 160,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -170,9 +165,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "package/name1",
-					Time:   160,
-					Result: parser.PASS,
+					Name: "package/name1",
+					Time: 160,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -189,9 +183,8 @@ var testCases = []TestCase{
 					},
 				},
 				{
-					Name:   "package/name2",
-					Time:   151,
-					Result: parser.FAIL,
+					Name: "package/name2",
+					Time: 151,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -222,9 +215,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "test/package",
-					Time:   160,
-					Result: parser.PASS,
+					Name: "test/package",
+					Time: 160,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -250,9 +242,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "github.com/dmitris/test-go-junit-report",
-					Time:   440,
-					Result: parser.PASS,
+					Name: "github.com/dmitris/test-go-junit-report",
+					Time: 440,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestDoFoo",
@@ -277,9 +268,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "package/name",
-					Time:   160,
-					Result: parser.PASS,
+					Name: "package/name",
+					Time: 160,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestZ",
@@ -305,9 +295,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "package1/foo",
-					Time:   400,
-					Result: parser.PASS,
+					Name: "package1/foo",
+					Time: 400,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestA",
@@ -325,9 +314,8 @@ var testCases = []TestCase{
 					CoveragePct: "10.0",
 				},
 				{
-					Name:   "package2/bar",
-					Time:   4200,
-					Result: parser.PASS,
+					Name: "package2/bar",
+					Time: 4200,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestC",
@@ -347,9 +335,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "package/name",
-					Time:   50,
-					Result: parser.PASS,
+					Name: "package/name",
+					Time: 50,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -374,9 +361,8 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "package/name",
-					Time:   50,
-					Result: parser.FAIL,
+					Name: "package/name",
+					Time: 50,
 					Tests: []*parser.Test{
 						{
 							Name:   "TestOne",
@@ -507,9 +493,54 @@ var testCases = []TestCase{
 		report: &parser.Report{
 			Packages: []parser.Package{
 				{
-					Name:   "package/name",
-					Result: parser.FAIL,
-					Tests:  []*parser.Test{},
+					Name: "package/name/passing1",
+					Time: 100,
+					Tests: []*parser.Test{
+						{
+							Name:   "TestA",
+							Time:   100,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+					},
+				},
+				{
+					Name: "package/name/passing2",
+					Time: 100,
+					Tests: []*parser.Test{
+						{
+							Name:   "TestB",
+							Time:   100,
+							Result: parser.PASS,
+							Output: []string{},
+						},
+					},
+				},
+				{
+					Name: "package/name/failing1",
+					Tests: []*parser.Test{
+						{
+							Name:   "build failed",
+							Time:   0,
+							Result: parser.FAIL,
+							Output: []string{
+								"failing1/failing_test.go:15: undefined: x",
+							},
+						},
+					},
+				},
+				{
+					Name: "package/name/failing2",
+					Tests: []*parser.Test{
+						{
+							Name:   "build failed",
+							Time:   0,
+							Result: parser.FAIL,
+							Output: []string{
+								"failing2/another_failing_test.go:20: undefined: y",
+							},
+						},
+					},
 				},
 			},
 		},

--- a/tests/13-report.xml
+++ b/tests/13-report.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="0" failures="0" time="0.000" name="package/name">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+	</testsuite>
+</testsuites>

--- a/tests/13-report.xml
+++ b/tests/13-report.xml
@@ -1,8 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="0" failures="0" time="0.000" name="package/name">
+	<testsuite tests="1" failures="0" time="0.100" name="package/name/passing1">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
+		<testcase classname="passing1" name="TestA" time="0.100"></testcase>
+	</testsuite>
+	<testsuite tests="1" failures="0" time="0.100" name="package/name/passing2">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="passing2" name="TestB" time="0.100"></testcase>
+	</testsuite>
+	<testsuite tests="1" failures="1" time="0.000" name="package/name/failing1">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="failing1" name="build failed" time="0.000">
+			<failure message="Failed" type="">failing1/failing_test.go:15: undefined: x</failure>
+		</testcase>
+	</testsuite>
+	<testsuite tests="1" failures="1" time="0.000" name="package/name/failing2">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="failing2" name="build failed" time="0.000">
+			<failure message="Failed" type="">failing2/another_failing_test.go:20: undefined: y</failure>
+		</testcase>
 	</testsuite>
 </testsuites>

--- a/tests/13-syntax-error.txt
+++ b/tests/13-syntax-error.txt
@@ -1,2 +1,14 @@
-package/name/file_test.go:9: undefined: x
-FAIL	package/name [build failed]
+# package/name/failing1
+failing1/failing_test.go:15: undefined: x
+# package/name/failing2
+failing2/another_failing_test.go:20: undefined: y
+=== RUN TestA
+--- PASS: TestA (0.10 seconds)
+PASS
+ok      package/name/passing1 0.100s
+=== RUN TestB
+--- PASS: TestB (0.10 seconds)
+PASS
+ok      package/name/passing2 0.100s
+FAIL    package/name/failing1 [build failed]
+FAIL    package/name/failing2 [build failed]

--- a/tests/13-syntax-error.txt
+++ b/tests/13-syntax-error.txt
@@ -1,0 +1,2 @@
+package/name/file_test.go:9: undefined: x
+FAIL	package/name [build failed]


### PR DESCRIPTION
Fixes #46 
In case of build error, the unittest fail, but the junit-report
with the set-exit-code flag on returns status code 0.
This commit will make it return the right status code.