### PR TITLE
Add "go-version" flag

### DIFF
--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -11,12 +11,14 @@ import (
 var (
 	noXMLHeader bool
 	packageName string
+	goVersionFlag string
 	setExitCode bool
 )
 
 func init() {
 	flag.BoolVar(&noXMLHeader, "no-xml-header", false, "do not print xml header")
 	flag.StringVar(&packageName, "package-name", "", "specify a package name (compiled test have no package name in output)")
+	flag.StringVar(&goVersionFlag, "go-version", "", "specify the value to use for the go.version property in the generated XML")
 	flag.BoolVar(&setExitCode, "set-exit-code", false, "set exit code to 1 if tests failed")
 }
 
@@ -31,7 +33,7 @@ func main() {
 	}
 
 	// Write xml
-	err = JUnitReportXML(report, noXMLHeader, os.Stdout)
+	err = JUnitReportXML(report, noXMLHeader, goVersionFlag, os.Stdout)
 	if err != nil {
 		fmt.Printf("Error writing XML: %s\n", err)
 		os.Exit(1)

--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -556,15 +556,23 @@ func TestParser(t *testing.T) {
 }
 
 func TestJUnitFormatter(t *testing.T) {
+	testJUnitFormatter(t, "")
+}
+
+func TestVersionFlag(t *testing.T) {
+	testJUnitFormatter(t, "custom-version")
+}
+
+func testJUnitFormatter(t *testing.T, goVersion string) {
 	for _, testCase := range testCases {
-		report, err := loadTestReport(testCase.reportName)
+		report, err := loadTestReport(testCase.reportName, goVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		var junitReport bytes.Buffer
 
-		if err = JUnitReportXML(testCase.report, testCase.noXMLHeader, &junitReport); err != nil {
+		if err = JUnitReportXML(testCase.report, testCase.noXMLHeader, goVersion, &junitReport); err != nil {
 			t.Fatal(err)
 		}
 
@@ -574,14 +582,19 @@ func TestJUnitFormatter(t *testing.T) {
 	}
 }
 
-func loadTestReport(name string) (string, error) {
+func loadTestReport(name, goVersion string) (string, error) {
 	contents, err := ioutil.ReadFile("tests/" + name)
 	if err != nil {
 		return "", err
 	}
 
+	if goVersion == "" {
+		// if goVersion is not specified, default to runtime version
+		goVersion = runtime.Version()
+	}
+
 	// replace value="1.0" With actual version
-	report := strings.Replace(string(contents), `value="1.0"`, fmt.Sprintf(`value="%s"`, runtime.Version()), -1)
+	report := strings.Replace(string(contents), `value="1.0"`, fmt.Sprintf(`value="%s"`, goVersion), -1)
 
 	return report, nil
 }

--- a/junit-formatter.go
+++ b/junit-formatter.go
@@ -59,7 +59,7 @@ type JUnitFailure struct {
 
 // JUnitReportXML writes a JUnit xml representation of the given report to w
 // in the format described at http://windyroad.org/dl/Open%20Source/JUnit.xsd
-func JUnitReportXML(report *parser.Report, noXMLHeader bool, w io.Writer) error {
+func JUnitReportXML(report *parser.Report, noXMLHeader bool, goVersion string, w io.Writer) error {
 	suites := JUnitTestSuites{}
 
 	// convert Report to JUnit test suites
@@ -79,7 +79,11 @@ func JUnitReportXML(report *parser.Report, noXMLHeader bool, w io.Writer) error 
 		}
 
 		// properties
-		ts.Properties = append(ts.Properties, JUnitProperty{"go.version", runtime.Version()})
+		if goVersion == "" {
+			// if goVersion was not specified as a flag, fall back to version reported by runtime
+			goVersion = runtime.Version()
+		}
+		ts.Properties = append(ts.Properties, JUnitProperty{"go.version", goVersion})
 		if pkg.CoveragePct != "" {
 			ts.Properties = append(ts.Properties, JUnitProperty{"coverage.statements.pct", pkg.CoveragePct})
 		}


### PR DESCRIPTION
Makes it so that the value of the "go.version" property in
the output XML can be customized by the caller using the
"go-version" flag. If the flag is unspecified, falls back to
the previous behavior of using runtime.Version() as the value.

Fixes #48