### PR TITLE
Include failing packages without tests in report

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -561,6 +561,55 @@ var testCases = []TestCase{
 			},
 		},
 	},
+	{
+		name:       "14-panic.txt",
+		reportName: "14-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name: "package/panic",
+					Time: 3,
+					Tests: []*parser.Test{
+						{
+							Name:   "Failure",
+							Result: parser.FAIL,
+							Output: []string{
+								"panic: init",
+								"stacktrace",
+							},
+						},
+					},
+				},
+				{
+					Name: "package/panic2",
+					Time: 3,
+					Tests: []*parser.Test{
+						{
+							Name:   "Failure",
+							Result: parser.FAIL,
+							Output: []string{
+								"panic: init",
+								"stacktrace",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name:       "15-empty.txt",
+		reportName: "15-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name:  "package/empty",
+					Time:  1,
+					Tests: []*parser.Test{},
+				},
+			},
+		},
+	},
 }
 
 func TestParser(t *testing.T) {

--- a/tests/14-panic.txt
+++ b/tests/14-panic.txt
@@ -1,0 +1,6 @@
+panic: init
+stacktrace
+FAIL    package/panic  0.003s
+panic: init
+stacktrace
+FAIL    package/panic2  0.003s

--- a/tests/14-report.xml
+++ b/tests/14-report.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="1" failures="1" time="0.003" name="package/panic">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="panic" name="Failure" time="0.000">
+			<failure message="Failed" type="">panic: init&#xA;stacktrace</failure>
+		</testcase>
+	</testsuite>
+	<testsuite tests="1" failures="1" time="0.003" name="package/panic2">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="panic2" name="Failure" time="0.000">
+			<failure message="Failed" type="">panic: init&#xA;stacktrace</failure>
+		</testcase>
+	</testsuite>
+</testsuites>

--- a/tests/15-empty.txt
+++ b/tests/15-empty.txt
@@ -1,0 +1,3 @@
+testing: warning: no tests to run
+PASS
+ok  	package/empty	0.001s

--- a/tests/15-report.xml
+++ b/tests/15-report.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="0" failures="0" time="0.001" name="package/empty">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
If a package compiles correctly, but panics before it has a chance to
run any tests it would previously be ignored. Any failing packages
without tests but with some output will now be included in the report
with a dummy test.

Fixes #52