### PR TITLE
Move `junit-formatter.go` to its own package for use as a library.

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,4 +1,4 @@
-package main
+package formatter
 
 import (
 	"bufio"

--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jstemmer/go-junit-report/formatter"
 	"github.com/jstemmer/go-junit-report/parser"
 )
 
@@ -33,7 +34,7 @@ func main() {
 	}
 
 	// Write xml
-	err = JUnitReportXML(report, noXMLHeader, goVersionFlag, os.Stdout)
+	err = formatter.JUnitReportXML(report, noXMLHeader, goVersionFlag, os.Stdout)
 	if err != nil {
 		fmt.Printf("Error writing XML: %s\n", err)
 		os.Exit(1)

--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jstemmer/go-junit-report/formatter"
 	"github.com/jstemmer/go-junit-report/parser"
 )
 
@@ -849,7 +850,7 @@ func testJUnitFormatter(t *testing.T, goVersion string) {
 
 		var junitReport bytes.Buffer
 
-		if err = JUnitReportXML(testCase.report, testCase.noXMLHeader, goVersion, &junitReport); err != nil {
+		if err = formatter.JUnitReportXML(testCase.report, testCase.noXMLHeader, goVersion, &junitReport); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
This lets JUnit xml generation be integrated into larger tools
instead of having to run the `go-junit-report` binary as a subprocess.