### PR TITLE
Adding json input support

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -23,7 +24,7 @@ type TestCase struct {
 
 var testCases = []TestCase{
 	{
-		name:       "01-pass.txt",
+		name:       "01-pass",
 		reportName: "01-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -49,7 +50,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "02-fail.txt",
+		name:       "02-fail",
 		reportName: "02-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -80,7 +81,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "03-skip.txt",
+		name:       "03-skip",
 		reportName: "03-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -108,7 +109,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "04-go_1_4.txt",
+		name:       "04-go_1_4",
 		reportName: "04-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -134,7 +135,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "05-no_xml_header.txt",
+		name:       "05-no_xml_header",
 		reportName: "05-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -161,7 +162,7 @@ var testCases = []TestCase{
 		noXMLHeader: true,
 	},
 	{
-		name:       "06-mixed.txt",
+		name:       "06-mixed",
 		reportName: "06-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -211,7 +212,7 @@ var testCases = []TestCase{
 		noXMLHeader: true,
 	},
 	{
-		name:       "07-compiled_test.txt",
+		name:       "07-compiled_test",
 		reportName: "07-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -238,7 +239,7 @@ var testCases = []TestCase{
 		packageName: "test/package",
 	},
 	{
-		name:       "08-parallel.txt",
+		name:       "08-parallel",
 		reportName: "08-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -264,7 +265,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "09-coverage.txt",
+		name:       "09-coverage",
 		reportName: "09-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -291,7 +292,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "10-multipkg-coverage.txt",
+		name:       "10-multipkg-coverage",
 		reportName: "10-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -331,7 +332,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "11-go_1_5.txt",
+		name:       "11-go_1_5",
 		reportName: "11-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -357,7 +358,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "12-go_1_7.txt",
+		name:       "12-go_1_7",
 		reportName: "12-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -489,7 +490,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "13-syntax-error.txt",
+		name:       "13-syntax-error",
 		reportName: "13-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -563,7 +564,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "14-panic.txt",
+		name:       "14-panic",
 		reportName: "14-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -599,7 +600,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "15-empty.txt",
+		name:       "15-empty",
 		reportName: "15-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -612,7 +613,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "16-repeated-names.txt",
+		name:       "16-repeated-names",
 		reportName: "16-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -644,7 +645,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "17-race.txt",
+		name:       "17-race",
 		reportName: "17-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -700,7 +701,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "18-coverpkg.txt",
+		name:       "18-coverpkg",
 		reportName: "18-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -740,7 +741,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "19-pass.txt",
+		name:       "19-pass",
 		reportName: "19-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -766,7 +767,7 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "20-parallel.txt",
+		name:       "20-parallel",
 		reportName: "20-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -810,66 +811,75 @@ var testCases = []TestCase{
 }
 
 func TestParser(t *testing.T) {
-	for _, testCase := range testCases {
-		t.Logf("Running: %s", testCase.name)
+	extensions := []string{"txt", "jsonl"}
+	for _, ext := range extensions {
 
-		file, err := os.Open("tests/" + testCase.name)
-		if err != nil {
-			t.Fatal(err)
-		}
+		for _, testCase := range testCases {
+			fname := filepath.Join("tests", testCase.name+"."+ext)
 
-		report, err := parser.Parse(file, testCase.packageName)
-		if err != nil {
-			t.Fatalf("error parsing: %s", err)
-		}
+			if _, err := os.Stat(fname); os.IsNotExist(err) {
+				continue
+			}
+			t.Logf("Running: %s.%s", testCase.name, ext)
 
-		if report == nil {
-			t.Fatalf("Report == nil")
-		}
-
-		expected := testCase.report
-		if len(report.Packages) != len(expected.Packages) {
-			t.Fatalf("Report packages == %d, want %d", len(report.Packages), len(expected.Packages))
-		}
-
-		for i, pkg := range report.Packages {
-			expPkg := expected.Packages[i]
-
-			if pkg.Name != expPkg.Name {
-				t.Errorf("Package.Name == %s, want %s", pkg.Name, expPkg.Name)
+			file, err := os.Open(fname)
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			if pkg.Time != expPkg.Time {
-				t.Errorf("Package.Time == %d, want %d", pkg.Time, expPkg.Time)
+			report, err := parser.Parse(file, testCase.packageName)
+			if err != nil {
+				t.Fatalf("error parsing: %s", err)
 			}
 
-			if len(pkg.Tests) != len(expPkg.Tests) {
-				t.Fatalf("Package Tests == %d, want %d", len(pkg.Tests), len(expPkg.Tests))
+			if report == nil {
+				t.Fatalf("Report == nil")
 			}
 
-			for j, test := range pkg.Tests {
-				expTest := expPkg.Tests[j]
-
-				if test.Name != expTest.Name {
-					t.Errorf("Test.Name == %s, want %s", test.Name, expTest.Name)
-				}
-
-				if test.Time != expTest.Time {
-					t.Errorf("Test.Time == %d, want %d", test.Time, expTest.Time)
-				}
-
-				if test.Result != expTest.Result {
-					t.Errorf("Test.Result == %d, want %d", test.Result, expTest.Result)
-				}
-
-				testOutput := strings.Join(test.Output, "\n")
-				expTestOutput := strings.Join(expTest.Output, "\n")
-				if testOutput != expTestOutput {
-					t.Errorf("Test.Output (%s) ==\n%s\n, want\n%s", test.Name, testOutput, expTestOutput)
-				}
+			expected := testCase.report
+			if len(report.Packages) != len(expected.Packages) {
+				t.Fatalf("Report packages == %d, want %d", len(report.Packages), len(expected.Packages))
 			}
-			if pkg.CoveragePct != expPkg.CoveragePct {
-				t.Errorf("Package.CoveragePct == %s, want %s", pkg.CoveragePct, expPkg.CoveragePct)
+
+			for i, pkg := range report.Packages {
+				expPkg := expected.Packages[i]
+
+				if pkg.Name != expPkg.Name {
+					t.Errorf("Package.Name == %s, want %s", pkg.Name, expPkg.Name)
+				}
+
+				if pkg.Time != expPkg.Time {
+					t.Errorf("Package.Time == %d, want %d", pkg.Time, expPkg.Time)
+				}
+
+				if len(pkg.Tests) != len(expPkg.Tests) {
+					t.Fatalf("Package Tests == %d, want %d", len(pkg.Tests), len(expPkg.Tests))
+				}
+
+				for j, test := range pkg.Tests {
+					expTest := expPkg.Tests[j]
+
+					if test.Name != expTest.Name {
+						t.Errorf("Test.Name == %s, want %s", test.Name, expTest.Name)
+					}
+
+					if test.Time != expTest.Time {
+						t.Errorf("Test.Time == %d, want %d", test.Time, expTest.Time)
+					}
+
+					if test.Result != expTest.Result {
+						t.Errorf("Test.Result == %d, want %d", test.Result, expTest.Result)
+					}
+
+					testOutput := strings.Join(test.Output, "\n")
+					expTestOutput := strings.Join(expTest.Output, "\n")
+					if testOutput != expTestOutput {
+						t.Errorf("Test.Output (%s) ==\n%s\n, want\n%s", test.Name, testOutput, expTestOutput)
+					}
+				}
+				if pkg.CoveragePct != expPkg.CoveragePct {
+					t.Errorf("Package.CoveragePct == %s, want %s", pkg.CoveragePct, expPkg.CoveragePct)
+				}
 			}
 		}
 	}

--- a/parser/jsonl.go
+++ b/parser/jsonl.go
@@ -1,0 +1,245 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// struct copied from https://godoc.org/github.com/golang/go/src/cmd/test2json
+type testEvent struct {
+	Time    time.Time // encodes as an RFC3339-format string
+	Action  string
+	Package string
+	Test    string
+	Elapsed float64 // seconds
+	Output  string
+}
+
+type testoutput []string
+
+func (o *testoutput) Append(s string) {
+	s = strings.TrimSuffix(s, "\n")
+	s = strings.TrimPrefix(s, "\t")
+	*o = append(*o, s)
+}
+
+type pkgoutput []string
+
+func (o *pkgoutput) Append(s string) {
+	statusPrefixes := []string{"FAIL", "PASS", "SKIP", "?"}
+	for _, prefix := range statusPrefixes {
+		if strings.HasPrefix(s, prefix) {
+			return
+		}
+	}
+	s = strings.TrimSuffix(s, "\n")
+	*o = append(*o, s)
+}
+
+type jsonlTest struct {
+	result  Result
+	output  testoutput
+	elapsed float64
+}
+
+type jsonlPackage struct {
+	tests           map[string]*jsonlTest
+	testsOrder      []string
+	elapsed         float64
+	coverage        string
+	output          pkgoutput
+	defaultTestName string
+}
+
+type jsonlParser struct {
+	pkgName       string
+	packages      map[string]*jsonlPackage
+	packagesOrder []string
+
+	currentlyBuiltPackage *jsonlPackage
+}
+
+func newJsonlParser(pkgName string) parser {
+	return &jsonlParser{
+		pkgName:  pkgName,
+		packages: make(map[string]*jsonlPackage),
+	}
+}
+
+func (p *jsonlParser) ingestJSONLine(line string) error {
+	var ev testEvent
+	err := json.Unmarshal([]byte(line), &ev)
+	if err != nil {
+		return err
+	}
+
+	act := ev.Action
+	if act == "pause" || act == "cont" {
+		return nil
+	}
+
+	if act == "run" {
+		return p.recordTest(ev)
+	}
+
+	if act == "pass" || act == "fail" || act == "skip" {
+		return p.recordResult(ev)
+	}
+
+	if act == "output" {
+		return p.recordOutput(ev)
+	}
+	return nil
+}
+
+func (p *jsonlParser) ingestBuildLine(line string) error {
+	if strings.HasPrefix(line, "FAIL ") {
+		cpts := regexp.MustCompile("\\s+").Split(line, 3)
+		if len(cpts) != 3 {
+			return fmt.Errorf("Invalid format: %v", cpts)
+		}
+		pkg := p.getPackage(cpts[1])
+		pkg.defaultTestName = cpts[2]
+		p.cookupFailure(cpts[1])
+		p.packagesOrder = append(p.packagesOrder, cpts[1])
+		return nil
+	}
+
+	if strings.HasPrefix(line, "# ") {
+		name := line[2:]
+		p.currentlyBuiltPackage = p.getPackage(name)
+	} else {
+		p.currentlyBuiltPackage.output.Append(line)
+	}
+	return nil
+}
+
+func (p *jsonlParser) IngestLine(line string) error {
+	if strings.HasPrefix(line, "{") {
+		return p.ingestJSONLine(line)
+	}
+	return p.ingestBuildLine(line)
+}
+
+func (p *jsonlParser) Report() (*Report, error) {
+	r := Report{
+		Packages: make([]Package, len(p.packages)),
+	}
+
+	for i, pname := range p.packagesOrder {
+		pkg := p.packages[pname]
+		tests := make([]*Test, len(pkg.tests))
+
+		for j, tname := range pkg.testsOrder {
+			t := pkg.tests[tname]
+			tests[j] = &Test{
+				Name:   tname,
+				Time:   int(t.elapsed * 1000),
+				Result: t.result,
+				Output: t.output,
+			}
+		}
+
+		r.Packages[i] = Package{
+			Name:        pname,
+			Time:        int(pkg.elapsed * 1000),
+			Tests:       tests,
+			CoveragePct: pkg.coverage,
+		}
+	}
+	return &r, nil
+}
+
+func (p *jsonlParser) recordTest(ev testEvent) error {
+	_ = p.getTest(ev.Package, ev.Test)
+	return nil
+}
+
+func (p *jsonlParser) cookupFailure(pck string) {
+	pkg := p.getPackage(pck)
+	t := p.getTest(pck, pkg.defaultTestName)
+	t.result = FAIL
+	t.output = testoutput(pkg.output)
+}
+
+func (p *jsonlParser) recordResult(ev testEvent) error {
+	pkg := p.getPackage(ev.Package)
+	if ev.Test == "" {
+		pkg.elapsed = ev.Elapsed
+		p.packagesOrder = append(p.packagesOrder, ev.Package)
+		if ev.Action == "fail" && len(pkg.tests) == 0 {
+			p.cookupFailure(ev.Package)
+		}
+		return nil
+	}
+
+	act := ev.Action
+	var status Result
+
+	switch act {
+	case "pass":
+		status = PASS
+	case "fail":
+		status = FAIL
+	default:
+		status = SKIP
+	}
+
+	t := p.getTest(ev.Package, ev.Test)
+	t.result = status
+	t.elapsed = ev.Elapsed
+	return nil
+}
+
+func (p *jsonlParser) recordOutput(ev testEvent) error {
+	out := ev.Output
+	// skip control messages as we should have a proper corresponding event
+	if strings.HasPrefix(out, "--- ") || strings.HasPrefix(out, "=== ") {
+		return nil
+	}
+	if ev.Test == "" {
+		pkg := p.getPackage(ev.Package)
+		if strings.HasPrefix(out, "coverage: ") {
+			cpts := strings.Split(out[10:], "%")
+			pct := cpts[0]
+			if !strings.Contains(pct, ".") {
+				pct = pct + ".0"
+			}
+			pkg.coverage = pct
+			return nil
+		}
+
+		pkg.output.Append(out)
+		return nil
+	}
+
+	p.getTest(ev.Package, ev.Test).output.Append(out)
+	return nil
+}
+
+func (p *jsonlParser) getPackage(pname string) *jsonlPackage {
+	if pkg, ok := p.packages[pname]; ok {
+		return pkg
+	}
+	pkg := &jsonlPackage{
+		tests:           make(map[string]*jsonlTest),
+		defaultTestName: "Failure",
+	}
+	p.packages[pname] = pkg
+	return pkg
+}
+
+func (p *jsonlParser) getTest(pname, tname string) *jsonlTest {
+	pkg := p.getPackage(pname)
+
+	if t, ok := pkg.tests[tname]; ok {
+		return t
+	}
+	t := &jsonlTest{}
+	pkg.tests[tname] = t
+	pkg.testsOrder = append(pkg.testsOrder, tname)
+	return t
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,9 +3,6 @@ package parser
 import (
 	"bufio"
 	"io"
-	"regexp"
-	"strconv"
-	"strings"
 )
 
 // Result represents a test result.
@@ -39,156 +36,9 @@ type Test struct {
 	Output []string
 }
 
-var (
-	regexStatus   = regexp.MustCompile(`--- (PASS|FAIL|SKIP): (.+) \((\d+\.\d+)(?: seconds|s)\)`)
-	regexCoverage = regexp.MustCompile(`^coverage:\s+(\d+\.\d+)%\s+of\s+statements(?:\sin\s.+)?$`)
-	regexResult   = regexp.MustCompile(`^(ok|FAIL)\s+([^ ]+)\s+(?:(\d+\.\d+)s|(\[\w+ failed]))(?:\s+coverage:\s+(\d+\.\d+)%\sof\sstatements(?:\sin\s.+)?)?$`)
-	regexOutput   = regexp.MustCompile(`(    )*\t(.*)`)
-	regexSummary  = regexp.MustCompile(`^(PASS|FAIL|SKIP)$`)
-)
-
 type parser interface {
 	IngestLine(string) error
 	Report() (*Report, error)
-}
-
-type textParser struct {
-	cur             string
-	capturedPackage string
-	tests           []*Test
-	report          *Report
-	testsTime       int
-	seenSummary     bool
-	coveragePct     string
-	packageCaptures map[string][]string
-	buffers         map[string][]string
-	pkgName         string
-}
-
-func newTextParser(pkgName string) parser {
-	return &textParser{
-		report:          &Report{make([]Package, 0)},
-		pkgName:         pkgName,
-		packageCaptures: make(map[string][]string),
-		buffers:         make(map[string][]string),
-	}
-}
-
-func (p *textParser) IngestLine(line string) error {
-	if strings.HasPrefix(line, "=== RUN ") {
-		// new test
-		p.cur = strings.TrimSpace(line[8:])
-		p.tests = append(p.tests, &Test{
-			Name:   p.cur,
-			Result: FAIL,
-			Output: make([]string, 0),
-		})
-
-		// clear the current build package, so output lines won't be added to that build
-		p.capturedPackage = ""
-		p.seenSummary = false
-	} else if strings.HasPrefix(line, "=== PAUSE ") {
-		return nil
-	} else if strings.HasPrefix(line, "=== CONT ") {
-		p.cur = strings.TrimSpace(line[8:])
-		return nil
-	} else if matches := regexResult.FindStringSubmatch(line); len(matches) == 6 {
-		if matches[5] != "" {
-			p.coveragePct = matches[5]
-		}
-		if strings.HasSuffix(matches[4], "failed]") {
-			// the build of the package failed, inject a dummy test into the package
-			// which indicate about the failure and contain the failure description.
-			p.tests = append(p.tests, &Test{
-				Name:   matches[4],
-				Result: FAIL,
-				Output: p.packageCaptures[matches[2]],
-			})
-		} else if matches[1] == "FAIL" && len(p.tests) == 0 && len(p.buffers[p.cur]) > 0 {
-			// This package didn't have any tests, but it failed with some
-			// output. Create a dummy test with the output.
-			p.tests = append(p.tests, &Test{
-				Name:   "Failure",
-				Result: FAIL,
-				Output: p.buffers[p.cur],
-			})
-			p.buffers[p.cur] = p.buffers[p.cur][0:0]
-		}
-
-		// all tests in this package are finished
-		p.report.Packages = append(p.report.Packages, Package{
-			Name:        matches[2],
-			Time:        parseTime(matches[3]),
-			Tests:       p.tests,
-			CoveragePct: p.coveragePct,
-		})
-
-		p.buffers[p.cur] = p.buffers[p.cur][0:0]
-		p.tests = make([]*Test, 0)
-		p.coveragePct = ""
-		p.cur = ""
-		p.testsTime = 0
-	} else if matches := regexStatus.FindStringSubmatch(line); len(matches) == 4 {
-		p.cur = matches[2]
-		test := findTest(p.tests, p.cur)
-		if test == nil {
-			return nil
-		}
-
-		// test status
-		if matches[1] == "PASS" {
-			test.Result = PASS
-		} else if matches[1] == "SKIP" {
-			test.Result = SKIP
-		} else {
-			test.Result = FAIL
-		}
-		test.Output = p.buffers[p.cur]
-
-		test.Name = matches[2]
-		testTime := parseTime(matches[3]) * 10
-		test.Time = testTime
-		p.testsTime += testTime
-	} else if matches := regexCoverage.FindStringSubmatch(line); len(matches) == 2 {
-		p.coveragePct = matches[1]
-	} else if matches := regexOutput.FindStringSubmatch(line); p.capturedPackage == "" && len(matches) == 3 {
-		// Sub-tests start with one or more series of 4-space indents, followed by a hard tab,
-		// followed by the test output
-		// Top-level tests start with a hard tab.
-		test := findTest(p.tests, p.cur)
-		if test == nil {
-			return nil
-		}
-		test.Output = append(test.Output, matches[2])
-	} else if strings.HasPrefix(line, "# ") {
-		// indicates a capture of build output of a package. set the current build package.
-		p.capturedPackage = line[2:]
-	} else if p.capturedPackage != "" {
-		// current line is build failure capture for the current built package
-		p.packageCaptures[p.capturedPackage] = append(p.packageCaptures[p.capturedPackage], line)
-	} else if regexSummary.MatchString(line) {
-		// don't store any output after the summary
-		p.seenSummary = true
-	} else if !p.seenSummary {
-		// buffer anything else that we didn't recognize
-		p.buffers[p.cur] = append(p.buffers[p.cur], line)
-	}
-
-	return nil
-}
-
-func (p *textParser) Report() (*Report, error) {
-	if len(p.tests) > 0 {
-		// no result line found
-		p.report.Packages = append(p.report.Packages, Package{
-			Name:        p.pkgName,
-			Time:        p.testsTime,
-			Tests:       p.tests,
-			CoveragePct: p.coveragePct,
-		})
-	}
-
-	return p.report, nil
 }
 
 // Parse parses go test output from reader r and returns a report with the
@@ -214,23 +64,6 @@ func Parse(r io.Reader, pkgName string) (*Report, error) {
 		}
 	}
 	return p.Report()
-}
-
-func parseTime(time string) int {
-	t, err := strconv.Atoi(strings.Replace(time, ".", "", -1))
-	if err != nil {
-		return 0
-	}
-	return t
-}
-
-func findTest(tests []*Test, name string) *Test {
-	for i := len(tests) - 1; i >= 0; i-- {
-		if tests[i].Name == name {
-			return tests[i]
-		}
-	}
-	return nil
 }
 
 // Failures counts the number of failed tests in this report

--- a/parser/text.go
+++ b/parser/text.go
@@ -1,0 +1,171 @@
+package parser
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	regexStatus   = regexp.MustCompile(`--- (PASS|FAIL|SKIP): (.+) \((\d+\.\d+)(?: seconds|s)\)`)
+	regexCoverage = regexp.MustCompile(`^coverage:\s+(\d+\.\d+)%\s+of\s+statements(?:\sin\s.+)?$`)
+	regexResult   = regexp.MustCompile(`^(ok|FAIL)\s+([^ ]+)\s+(?:(\d+\.\d+)s|(\[\w+ failed]))(?:\s+coverage:\s+(\d+\.\d+)%\sof\sstatements(?:\sin\s.+)?)?$`)
+	regexOutput   = regexp.MustCompile(`(    )*\t(.*)`)
+	regexSummary  = regexp.MustCompile(`^(PASS|FAIL|SKIP)$`)
+)
+
+type textParser struct {
+	cur             string
+	capturedPackage string
+	tests           []*Test
+	report          *Report
+	testsTime       int
+	seenSummary     bool
+	coveragePct     string
+	packageCaptures map[string][]string
+	buffers         map[string][]string
+	pkgName         string
+}
+
+func newTextParser(pkgName string) parser {
+	return &textParser{
+		report:          &Report{make([]Package, 0)},
+		pkgName:         pkgName,
+		packageCaptures: make(map[string][]string),
+		buffers:         make(map[string][]string),
+	}
+}
+
+func (p *textParser) IngestLine(line string) error {
+	if strings.HasPrefix(line, "=== RUN ") {
+		// new test
+		p.cur = strings.TrimSpace(line[8:])
+		p.tests = append(p.tests, &Test{
+			Name:   p.cur,
+			Result: FAIL,
+			Output: make([]string, 0),
+		})
+
+		// clear the current build package, so output lines won't be added to that build
+		p.capturedPackage = ""
+		p.seenSummary = false
+	} else if strings.HasPrefix(line, "=== PAUSE ") {
+		return nil
+	} else if strings.HasPrefix(line, "=== CONT ") {
+		p.cur = strings.TrimSpace(line[8:])
+		return nil
+	} else if matches := regexResult.FindStringSubmatch(line); len(matches) == 6 {
+		if matches[5] != "" {
+			p.coveragePct = matches[5]
+		}
+		if strings.HasSuffix(matches[4], "failed]") {
+			// the build of the package failed, inject a dummy test into the package
+			// which indicate about the failure and contain the failure description.
+			p.tests = append(p.tests, &Test{
+				Name:   matches[4],
+				Result: FAIL,
+				Output: p.packageCaptures[matches[2]],
+			})
+		} else if matches[1] == "FAIL" && len(p.tests) == 0 && len(p.buffers[p.cur]) > 0 {
+			// This package didn't have any tests, but it failed with some
+			// output. Create a dummy test with the output.
+			p.tests = append(p.tests, &Test{
+				Name:   "Failure",
+				Result: FAIL,
+				Output: p.buffers[p.cur],
+			})
+			p.buffers[p.cur] = p.buffers[p.cur][0:0]
+		}
+
+		// all tests in this package are finished
+		p.report.Packages = append(p.report.Packages, Package{
+			Name:        matches[2],
+			Time:        parseTime(matches[3]),
+			Tests:       p.tests,
+			CoveragePct: p.coveragePct,
+		})
+
+		p.buffers[p.cur] = p.buffers[p.cur][0:0]
+		p.tests = make([]*Test, 0)
+		p.coveragePct = ""
+		p.cur = ""
+		p.testsTime = 0
+	} else if matches := regexStatus.FindStringSubmatch(line); len(matches) == 4 {
+		p.cur = matches[2]
+		test := findTest(p.tests, p.cur)
+		if test == nil {
+			return nil
+		}
+
+		// test status
+		if matches[1] == "PASS" {
+			test.Result = PASS
+		} else if matches[1] == "SKIP" {
+			test.Result = SKIP
+		} else {
+			test.Result = FAIL
+		}
+		test.Output = p.buffers[p.cur]
+
+		test.Name = matches[2]
+		testTime := parseTime(matches[3]) * 10
+		test.Time = testTime
+		p.testsTime += testTime
+	} else if matches := regexCoverage.FindStringSubmatch(line); len(matches) == 2 {
+		p.coveragePct = matches[1]
+	} else if matches := regexOutput.FindStringSubmatch(line); p.capturedPackage == "" && len(matches) == 3 {
+		// Sub-tests start with one or more series of 4-space indents, followed by a hard tab,
+		// followed by the test output
+		// Top-level tests start with a hard tab.
+		test := findTest(p.tests, p.cur)
+		if test == nil {
+			return nil
+		}
+		test.Output = append(test.Output, matches[2])
+	} else if strings.HasPrefix(line, "# ") {
+		// indicates a capture of build output of a package. set the current build package.
+		p.capturedPackage = line[2:]
+	} else if p.capturedPackage != "" {
+		// current line is build failure capture for the current built package
+		p.packageCaptures[p.capturedPackage] = append(p.packageCaptures[p.capturedPackage], line)
+	} else if regexSummary.MatchString(line) {
+		// don't store any output after the summary
+		p.seenSummary = true
+	} else if !p.seenSummary {
+		// buffer anything else that we didn't recognize
+		p.buffers[p.cur] = append(p.buffers[p.cur], line)
+	}
+
+	return nil
+}
+
+func (p *textParser) Report() (*Report, error) {
+	if len(p.tests) > 0 {
+		// no result line found
+		p.report.Packages = append(p.report.Packages, Package{
+			Name:        p.pkgName,
+			Time:        p.testsTime,
+			Tests:       p.tests,
+			CoveragePct: p.coveragePct,
+		})
+	}
+
+	return p.report, nil
+}
+
+func parseTime(time string) int {
+	t, err := strconv.Atoi(strings.Replace(time, ".", "", -1))
+	if err != nil {
+		return 0
+	}
+	return t
+}
+
+func findTest(tests []*Test, name string) *Test {
+	for i := len(tests) - 1; i >= 0; i-- {
+		if tests[i].Name == name {
+			return tests[i]
+		}
+	}
+	return nil
+}

--- a/tests/01-pass.jsonl
+++ b/tests/01-pass.jsonl
@@ -1,0 +1,9 @@
+{"Action":"output","Package":"package/name","Output":"=== RUN TestZ\n"}
+{"Action":"output","Package":"package/name","Test":"TestZ","Output":"--- PASS: TestZ (0.06 seconds)\n"}
+{"Action":"output","Package":"package/name","Test":"TestZ","Output":"=== RUN TestA\n"}
+{"Action":"pass","Package":"package/name","Test":"TestZ","Elapsed":0.06}
+{"Action":"output","Package":"package/name","Test":"TestA","Output":"--- PASS: TestA (0.10 seconds)\n"}
+{"Action":"pass","Package":"package/name","Test":"TestA","Elapsed":0.10}
+{"Action":"output","Package":"package/name","Output":"PASS\n"}
+{"Action":"output","Package":"package/name","Output":"ok  \tpackage/name 0.160s\n"}
+{"Action":"pass","Package":"package/name","Elapsed":0.16}

--- a/tests/02-fail.jsonl
+++ b/tests/02-fail.jsonl
@@ -1,0 +1,14 @@
+{"Action":"output","Package":"package/name","Output":"=== RUN TestOne\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"--- FAIL: TestOne (0.02 seconds)\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"\tfile_test.go:11: Error message\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"\tfile_test.go:11: Longer\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"\t\terror\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"\t\tmessage.\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"=== RUN TestTwo\n"}
+{"Action":"fail","Package":"package/name","Test":"TestOne","Elapsed":0.02}
+{"Action":"output","Package":"package/name","Test":"TestTwo","Output":"--- PASS: TestTwo (0.13 seconds)\n"}
+{"Action":"pass","Package":"package/name","Test":"TestTwo","Elapsed":0.13}
+{"Action":"output","Package":"package/name","Output":"FAIL\n"}
+{"Action":"output","Package":"package/name","Output":"exit status 1\n"}
+{"Action":"output","Package":"package/name","Output":"FAIL\tpackage/name 0.151s\n"}
+{"Action":"fail","Package":"package/name","Elapsed":0.151}

--- a/tests/03-skip.jsonl
+++ b/tests/03-skip.jsonl
@@ -1,0 +1,10 @@
+{"Action":"output","Package":"package/name","Output":"=== RUN TestOne\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"--- SKIP: TestOne (0.02 seconds)\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"\tfile_test.go:11: Skip message\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"=== RUN TestTwo\n"}
+{"Action":"skip","Package":"package/name","Test":"TestOne","Elapsed":0.02}
+{"Action":"output","Package":"package/name","Test":"TestTwo","Output":"--- PASS: TestTwo (0.13 seconds)\n"}
+{"Action":"pass","Package":"package/name","Test":"TestTwo","Elapsed":0.13}
+{"Action":"output","Package":"package/name","Output":"PASS\n"}
+{"Action":"output","Package":"package/name","Output":"ok\tpackage/name 0.150s\n"}
+{"Action":"pass","Package":"package/name","Elapsed":0.15}

--- a/tests/04-go_1_4.jsonl
+++ b/tests/04-go_1_4.jsonl
@@ -1,0 +1,9 @@
+{"Action":"output","Package":"package/name","Output":"=== RUN TestOne\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"--- PASS: TestOne (0.06s)\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"=== RUN TestTwo\n"}
+{"Action":"pass","Package":"package/name","Test":"TestOne","Elapsed":0.06}
+{"Action":"output","Package":"package/name","Test":"TestTwo","Output":"--- PASS: TestTwo (0.10s)\n"}
+{"Action":"pass","Package":"package/name","Test":"TestTwo","Elapsed":0.1}
+{"Action":"output","Package":"package/name","Output":"PASS\n"}
+{"Action":"output","Package":"package/name","Output":"ok  \tpackage/name\t0.160s"}
+{"Action":"pass","Package":"package/name","Elapsed":0.16}

--- a/tests/05-no_xml_header.jsonl
+++ b/tests/05-no_xml_header.jsonl
@@ -1,0 +1,9 @@
+{"Action":"output","Package":"package/name","Output":"=== RUN TestOne\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"--- PASS: TestOne (0.06s)\n"}
+{"Action":"output","Package":"package/name","Test":"TestOne","Output":"=== RUN TestTwo\n"}
+{"Action":"pass","Package":"package/name","Test":"TestOne","Elapsed":0.06}
+{"Action":"output","Package":"package/name","Test":"TestTwo","Output":"--- PASS: TestTwo (0.10s)\n"}
+{"Action":"pass","Package":"package/name","Test":"TestTwo","Elapsed":0.1}
+{"Action":"output","Package":"package/name","Output":"PASS\n"}
+{"Action":"output","Package":"package/name","Output":"ok  \tpackage/name\t0.160s"}
+{"Action":"pass","Package":"package/name","Elapsed":0.16}

--- a/tests/06-mixed.jsonl
+++ b/tests/06-mixed.jsonl
@@ -1,0 +1,23 @@
+{"Action":"output","Package":"package/name1","Output":"=== RUN TestOne\n"}
+{"Action":"output","Package":"package/name1","Test":"TestOne","Output":"--- PASS: TestOne (0.06 seconds)\n"}
+{"Action":"output","Package":"package/name1","Test":"TestOne","Output":"=== RUN TestTwo\n"}
+{"Action":"pass","Package":"package/name1","Test":"TestOne","Elapsed":0.06}
+{"Action":"output","Package":"package/name1","Test":"TestTwo","Output":"--- PASS: TestTwo (0.10 seconds)\n"}
+{"Action":"pass","Package":"package/name1","Test":"TestTwo","Elapsed":0.1}
+{"Action":"output","Package":"package/name1","Output":"PASS\n"}
+{"Action":"output","Package":"package/name1","Output":"ok  \tpackage/name1 0.160s\n"}
+{"Action":"pass","Package":"package/name1","Elapsed":0.16}
+{"Action":"output","Package":"package/name2","Output":"=== RUN TestOne\n"}
+{"Action":"output","Package":"package/name2","Test":"TestOne","Output":"--- FAIL: TestOne (0.02 seconds)\n"}
+{"Action":"output","Package":"package/name2","Test":"TestOne","Output":"\tfile_test.go:11: Error message\n"}
+{"Action":"output","Package":"package/name2","Test":"TestOne","Output":"\tfile_test.go:11: Longer\n"}
+{"Action":"output","Package":"package/name2","Test":"TestOne","Output":"\t\terror\n"}
+{"Action":"output","Package":"package/name2","Test":"TestOne","Output":"\t\tmessage.\n"}
+{"Action":"output","Package":"package/name2","Test":"TestOne","Output":"=== RUN TestTwo\n"}
+{"Action":"fail","Package":"package/name2","Test":"TestOne","Elapsed":0.02}
+{"Action":"output","Package":"package/name2","Test":"TestTwo","Output":"--- PASS: TestTwo (0.13 seconds)\n"}
+{"Action":"pass","Package":"package/name2","Test":"TestTwo","Elapsed":0.13}
+{"Action":"output","Package":"package/name2","Output":"FAIL\n"}
+{"Action":"output","Package":"package/name2","Output":"exit status 1\n"}
+{"Action":"output","Package":"package/name2","Output":"FAIL\tpackage/name2 0.151s\n"}
+{"Action":"fail","Package":"package/name2","Elapsed":0.151}

--- a/tests/07-compiled_test.jsonl
+++ b/tests/07-compiled_test.jsonl
@@ -1,0 +1,7 @@
+{"Action":"output","Package":"test/package","Output":"=== RUN TestOne\n"}
+{"Action":"output","Package":"test/package","Test":"TestOne","Output":"--- PASS: TestOne (0.06s)\n"}
+{"Action":"output","Package":"test/package","Test":"TestOne","Output":"=== RUN TestTwo\n"}
+{"Action":"pass","Package":"test/package","Test":"TestOne","Elapsed":0.06}
+{"Action":"output","Package":"test/package","Test":"TestTwo","Output":"--- PASS: TestTwo (0.10s)\n"}
+{"Action":"pass","Package":"test/package","Test":"TestTwo","Elapsed":0.1}
+{"Action":"pass","Package":"test/package","Elapsed":0.16}

--- a/tests/08-parallel.jsonl
+++ b/tests/08-parallel.jsonl
@@ -1,0 +1,13 @@
+{"Action":"output","Package":"github.com/dmitris/test-go-junit-report","Output":"=== RUN TestDoFoo\n"}
+{"Action":"output","Package":"github.com/dmitris/test-go-junit-report","Output":"=== RUN TestDoFoo2\n"}
+{"Action":"output","Package":"github.com/dmitris/test-go-junit-report","Test":"TestDoFoo","Output":"--- PASS: TestDoFoo (0.27s)\n"}
+{"Action":"output","Package":"github.com/dmitris/test-go-junit-report","Test":"TestDoFoo","Output":"\tcov_test.go:10: DoFoo log 1\n"}
+{"Action":"output","Package":"github.com/dmitris/test-go-junit-report","Test":"TestDoFoo","Output":"\tcov_test.go:10: DoFoo log 2\n"}
+{"Action":"pass","Package":"github.com/dmitris/test-go-junit-report","Test":"TestDoFoo","Elapsed":0.27}
+{"Action":"output","Package":"github.com/dmitris/test-go-junit-report","Test":"TestDoFoo2","Output":"--- PASS: TestDoFoo2 (0.16s)\n"}
+{"Action":"output","Package":"github.com/dmitris/test-go-junit-report","Test":"TestDoFoo2","Output":"\tcov_test.go:21: DoFoo2 log 1\n"}
+{"Action":"output","Package":"github.com/dmitris/test-go-junit-report","Test":"TestDoFoo2","Output":"\tcov_test.go:21: DoFoo2 log 2\n"}
+{"Action":"pass","Package":"github.com/dmitris/test-go-junit-report","Test":"TestDoFoo2","Elapsed":0.16}
+{"Action":"output","Package":"github.com/dmitris/test-go-junit-report","Output":"PASS\n"}
+{"Action":"output","Package":"github.com/dmitris/test-go-junit-report","Output":"ok  \tgithub.com/dmitris/test-go-junit-report\t0.440s\n"}
+{"Action":"pass","Package":"github.com/dmitris/test-go-junit-report","Elapsed":0.44}

--- a/tests/09-coverage.jsonl
+++ b/tests/09-coverage.jsonl
@@ -1,0 +1,10 @@
+{"Action":"output","Package":"package/name","Output":"=== RUN TestZ\n"}
+{"Action":"output","Package":"package/name","Test":"TestZ","Output":"--- PASS: TestZ (0.06 seconds)\n"}
+{"Action":"output","Package":"package/name","Test":"TestZ","Output":"=== RUN TestA\n"}
+{"Action":"pass","Package":"package/name","Test":"TestZ","Elapsed":0.06}
+{"Action":"output","Package":"package/name","Test":"TestA","Output":"--- PASS: TestA (0.10 seconds)\n"}
+{"Action":"pass","Package":"package/name","Test":"TestA","Elapsed":0.1}
+{"Action":"output","Package":"package/name","Output":"PASS\n"}
+{"Action":"output","Package":"package/name","Output":"coverage: 13.37% of statements\n"}
+{"Action":"output","Package":"package/name","Output":"ok  \tpackage/name 0.160s\n"}
+{"Action":"pass","Package":"package/name","Elapsed":0.16}

--- a/tests/10-multipkg-coverage.jsonl
+++ b/tests/10-multipkg-coverage.jsonl
@@ -1,0 +1,17 @@
+{"Action":"output","Package":"package1/foo","Output":"=== RUN TestA\n"}
+{"Action":"output","Package":"package1/foo","Test":"TestA","Output":"--- PASS: TestA (0.10 seconds)\n"}
+{"Action":"output","Package":"package1/foo","Test":"TestA","Output":"=== RUN TestB\n"}
+{"Action":"pass","Package":"package1/foo","Test":"TestA","Elapsed":0.1}
+{"Action":"output","Package":"package1/foo","Test":"TestB","Output":"--- PASS: TestB (0.30 seconds)\n"}
+{"Action":"pass","Package":"package1/foo","Test":"TestB","Elapsed":0.3}
+{"Action":"output","Package":"package1/foo","Output":"PASS\n"}
+{"Action":"output","Package":"package1/foo","Output":"coverage: 10% of statements\n"}
+{"Action":"output","Package":"package1/foo","Output":"ok  \tpackage1/foo 0.400s  coverage: 10.0% of statements\n"}
+{"Action":"pass","Package":"package1/foo","Elapsed":0.4}
+{"Action":"output","Package":"package2/bar","Output":"=== RUN TestC\n"}
+{"Action":"output","Package":"package2/bar","Test":"TestC","Output":"--- PASS: TestC (4.20 seconds)\n"}
+{"Action":"pass","Package":"package2/bar","Test":"TestC","Elapsed":4.2}
+{"Action":"output","Package":"package2/bar","Output":"PASS\n"}
+{"Action":"output","Package":"package2/bar","Output":"coverage: 99.8% of statements\n"}
+{"Action":"output","Package":"package2/bar","Output":"ok  \tpackage2/bar 4.200s  coverage: 99.8% of statements\n"}
+{"Action":"pass","Package":"package2/bar","Elapsed":4.2}

--- a/tests/13-syntax-error.jsonl
+++ b/tests/13-syntax-error.jsonl
@@ -1,0 +1,22 @@
+# package/name/failing1
+failing1/failing_test.go:15: undefined: x
+# package/name/failing2
+failing2/another_failing_test.go:20: undefined: y
+# package/name/setupfailing1
+setupfailing1/failing_test.go:4: cannot find package "other/package" in any of:
+	/path/vendor (vendor tree)
+	/path/go/root (from $GOROOT)
+	/path/go/path (from $GOPATH)
+{"Action":"run","Package":"package/name/passing1","Test":"TestA"}
+{"Action":"output","Package":"package/name/passing1","Output":"=== RUN TestA\n"}
+{"Action":"output","Package":"package/name/passing1","Test":"TestA","Output":"--- PASS: TestA (0.10 seconds)\n"}
+{"Action":"pass","Package":"package/name/passing1","Test":"TestA","Elapsed":0.1}
+{"Action":"pass","Package":"package/name/passing1","Elapsed":0.1}
+{"Action":"run","Package":"package/name/passing2","Test":"TestB"}
+{"Action":"output","Package":"package/name/passing2","Output":"=== RUN TestB\n"}
+{"Action":"output","Package":"package/name/passing2","Test":"TestB","Output":"--- PASS: TestB (0.10 seconds)\n"}
+{"Action":"pass","Package":"package/name/passing2","Test":"TestB","Elapsed":0.1}
+{"Action":"pass","Package":"package/name/passing2","Elapsed":0.1}
+FAIL    package/name/failing1 [build failed]
+FAIL    package/name/failing2 [build failed]
+FAIL    package/name/setupfailing1 [setup failed]

--- a/tests/14-panic.jsonl
+++ b/tests/14-panic.jsonl
@@ -1,0 +1,8 @@
+{"Action":"output","Package":"package/panic","Output":"panic: init\n"}
+{"Action":"output","Package":"package/panic","Output":"stacktrace\n"}
+{"Action":"output","Package":"package/panic","Output":"FAIL    package/panic  0.003s\n"}
+{"Action":"fail","Package":"package/panic","Elapsed":0.003}
+{"Action":"output","Package":"package/panic2","Output":"panic: init\n"}
+{"Action":"output","Package":"package/panic2","Output":"stacktrace\n"}
+{"Action":"output","Package":"package/panic2","Output":"FAIL    package/panic2  0.003s\n"}
+{"Action":"fail","Package":"package/panic2","Elapsed":0.003}

--- a/tests/15-empty.jsonl
+++ b/tests/15-empty.jsonl
@@ -1,0 +1,4 @@
+{"Action":"output","Package":"package/empty","Output":"testing: warning: no tests to run\n"}
+{"Action":"output","Package":"package/empty","Output":"PASS\n"}
+{"Action":"output","Package":"package/empty","Output":"ok  \tpackage/empty\t0.001s\n"}
+{"Action":"pass","Package":"package/empty","Elapsed":0.001}

--- a/tests/17-race.jsonl
+++ b/tests/17-race.jsonl
@@ -1,0 +1,43 @@
+{"Action":"run","Package":"race_test","Test":"TestRace"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"=== RUN   TestRace\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"test output\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"2 0xc4200153d0\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"==================\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"WARNING: DATA RACE\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"Write at 0x00c4200153d0 by goroutine 7:\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"  race_test.TestRace.func1()\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"      race_test.go:13 +0x3b\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"Previous write at 0x00c4200153d0 by goroutine 6:\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"  race_test.TestRace()\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"      race_test.go:15 +0x136\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"  testing.tRunner()\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"      /usr/local/Cellar/go/1.8.3/libexec/src/testing/testing.go:657 +0x107\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"Goroutine 7 (running) created at:\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"  race_test.TestRace()\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"      race_test.go:14 +0x125\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"  testing.tRunner()\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"      /usr/local/Cellar/go/1.8.3/libexec/src/testing/testing.go:657 +0x107\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"Goroutine 6 (running) created at:\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"  testing.(*T).Run()\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"      /usr/local/Cellar/go/1.8.3/libexec/src/testing/testing.go:697 +0x543\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"  testing.runTests.func1()\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"      /usr/local/Cellar/go/1.8.3/libexec/src/testing/testing.go:882 +0xaa\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"  testing.tRunner()\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"      /usr/local/Cellar/go/1.8.3/libexec/src/testing/testing.go:657 +0x107\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"  testing.runTests()\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"      /usr/local/Cellar/go/1.8.3/libexec/src/testing/testing.go:888 +0x4e0\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"  testing.(*M).Run()\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"      /usr/local/Cellar/go/1.8.3/libexec/src/testing/testing.go:822 +0x1c3\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"  main.main()\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"      _test/_testmain.go:52 +0x20f\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"==================\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"--- FAIL: TestRace (0.00s)\n"}
+{"Action":"output","Package":"race_test","Test":"TestRace","Output":"\ttesting.go:610: race detected during execution of test\n"}
+{"Action":"fail","Package":"race_test","Test":"TestRace"}
+{"Action":"output","Package":"race_test","Output":"FAIL\n"}
+{"Action":"output","Package":"race_test","Output":"exit status 1\n"}
+{"Action":"output","Package":"race_test","Output":"FAIL\trace_test\t0.015s"}
+{"Action":"fail","Package":"race_test","Elapsed":0.015}

--- a/tests/18-coverpkg.jsonl
+++ b/tests/18-coverpkg.jsonl
@@ -1,0 +1,17 @@
+{"Action":"output","Package":"package1/foo","Output":"=== RUN TestA\n"}
+{"Action":"output","Package":"package1/foo","Test":"TestA","Output":"--- PASS: TestA (0.10 seconds)\n"}
+{"Action":"output","Package":"package1/foo","Test":"TestA","Output":"=== RUN TestB\n"}
+{"Action":"pass","Package":"package1/foo","Test":"TestA","Elapsed":0.1}
+{"Action":"output","Package":"package1/foo","Test":"TestB","Output":"--- PASS: TestB (0.30 seconds)\n"}
+{"Action":"pass","Package":"package1/foo","Test":"TestB","Elapsed":0.3}
+{"Action":"output","Package":"package1/foo","Output":"PASS\n"}
+{"Action":"output","Package":"package1/foo","Output":"coverage: 10% of statements in fmt, encoding/xml\n"}
+{"Action":"output","Package":"package1/foo","Output":"ok  \tpackage1/foo 0.400s  coverage: 10.0% of statements in fmt, encoding/xml\n"}
+{"Action":"pass","Package":"package1/foo","Elapsed":0.4}
+{"Action":"output","Package":"package2/bar","Output":"=== RUN TestC\n"}
+{"Action":"output","Package":"package2/bar","Test":"TestC","Output":"--- PASS: TestC (4.20 seconds)\n"}
+{"Action":"pass","Package":"package2/bar","Test":"TestC","Elapsed":4.2}
+{"Action":"output","Package":"package2/bar","Output":"PASS\n"}
+{"Action":"output","Package":"package2/bar","Output":"coverage: 99.8% of statements in fmt, encoding/xml\n"}
+{"Action":"output","Package":"package2/bar","Output":"ok  \tpackage2/bar 4.200s  coverage: 99.8% of statements in fmt, encoding/xml\n"}
+{"Action":"pass","Package":"package2/bar","Elapsed":4.2}

--- a/tests/20-parallel.jsonl
+++ b/tests/20-parallel.jsonl
@@ -1,0 +1,29 @@
+{"Action":"run","Package":"pkg/parallel","Test":"FirstTest"}
+{"Action":"output","Package":"pkg/parallel","Test":"FirstTest","Output":"=== RUN   FirstTest\n"}
+{"Action":"output","Package":"pkg/parallel","Test":"FirstTest","Output":"Message from first\n"}
+{"Action":"output","Package":"pkg/parallel","Test":"FirstTest","Output":"=== PAUSE FirstTest\n"}
+{"Action":"pause","Package":"pkg/parallel","Test":"FirstTest"}
+{"Action":"run","Package":"pkg/parallel","Test":"SecondTest"}
+{"Action":"output","Package":"pkg/parallel","Test":"SecondTest","Output":"=== RUN   SecondTest\n"}
+{"Action":"output","Package":"pkg/parallel","Test":"SecondTest","Output":"Message from second\n"}
+{"Action":"output","Package":"pkg/parallel","Test":"SecondTest","Output":"=== PAUSE SecondTest\n"}
+{"Action":"pause","Package":"pkg/parallel","Test":"SecondTest"}
+{"Action":"cont","Package":"pkg/parallel","Test":"FirstTest"}
+{"Action":"output","Package":"pkg/parallel","Test":"FirstTest","Output":"=== CONT  FirstTest\n"}
+{"Action":"output","Package":"pkg/parallel","Test":"FirstTest","Output":"Supplemental from first\n"}
+{"Action":"run","Package":"pkg/parallel","Test":"ThirdTest"}
+{"Action":"output","Package":"pkg/parallel","Test":"ThirdTest","Output":"=== RUN   ThirdTest\n"}
+{"Action":"output","Package":"pkg/parallel","Test":"ThirdTest","Output":"Message from third\n"}
+{"Action":"output","Package":"pkg/parallel","Test":"ThirdTest","Output":"--- FAIL: ThirdTest (0.01s)\n"}
+{"Action":"output","Package":"pkg/parallel","Test":"ThirdTest","Output":"\tparallel_test.go:32: ThirdTest error\n"}
+{"Action":"fail","Package":"pkg/parallel","Test":"ThirdTest","Elapsed":0.01}
+{"Action":"output","Package":"pkg/parallel","Test":"FirstTest","Output":"--- FAIL: FirstTest (2.00s)\n"}
+{"Action":"output","Package":"pkg/parallel","Test":"FirstTest","Output":"\tparallel_test.go:14: FirstTest error\n"}
+{"Action":"fail","Package":"pkg/parallel","Test":"FirstTest","Elapsed":2.0}
+{"Action":"output","Package":"pkg/parallel","Test":"SecondTest","Output":"--- FAIL: SecondTest (1.00s)\n"}
+{"Action":"output","Package":"pkg/parallel","Test":"SecondTest","Output":"\tparallel_test.go:23: SecondTest error\n"}
+{"Action":"fail","Package":"pkg/parallel","Test":"SecondTest","Elapsed":1.0}
+{"Action":"output","Package":"pkg/parallel","Output":"FAIL\n"}
+{"Action":"output","Package":"pkg/parallel","Output":"exit status 1\n"}
+{"Action":"output","Package":"pkg/parallel","Output":"FAIL\tpkg/parallel\t3.010s\n"}
+{"Action":"fail","Package":"pkg/parallel","Elapsed":3.01}


### PR DESCRIPTION
This change enables `go-junit-report` to consume the output of `go test -json`.

It introduces an abstract parser interface, some code to automatically select which parser is relevant, and a port of all relevant test cases to validate both text and json formats.

This is an attempt at addressing #66 