### PR TITLE
Regex captures benchmarks with or without CPU suffix

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -1174,6 +1174,44 @@ var testCases = []TestCase{
 			},
 		},
 	},
+	{
+		name:       "28-bench-1cpu.txt",
+		reportName: "28-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name:     "single/cpu",
+					Duration: 9467 * time.Millisecond,
+					Time:     9467,
+					Benchmarks: []*parser.Benchmark{
+						{
+							Name:     "BenchmarkRing",
+							Duration: 74 * time.Nanosecond,
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name:       "29-bench-16cpu.txt",
+		reportName: "29-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name:     "sixteen/cpu",
+					Duration: 1522 * time.Millisecond,
+					Time:     1522,
+					Benchmarks: []*parser.Benchmark{
+						{
+							Name:     "BenchmarkRingaround",
+							Duration: 13571 * time.Nanosecond,
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestParser(t *testing.T) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -62,7 +62,7 @@ var (
 	regexCoverage = regexp.MustCompile(`^coverage:\s+(\d+\.\d+)%\s+of\s+statements(?:\sin\s.+)?$`)
 	regexResult   = regexp.MustCompile(`^(ok|FAIL)\s+([^ ]+)\s+(?:(\d+\.\d+)s|\(cached\)|(\[\w+ failed]))(?:\s+coverage:\s+(\d+\.\d+)%\sof\sstatements(?:\sin\s.+)?)?$`)
 	// regexBenchmark captures 3-5 groups: benchmark name, number of times ran, ns/op (with or without decimal), B/op (optional), and allocs/op (optional).
-	regexBenchmark = regexp.MustCompile(`^(Benchmark[^ ]+)-\d\s+(\d+)\s+(\d+|\d+\.\d+)\sns/op(?:\s+(\d+)\sB/op)?(?:\s+(\d+)\sallocs/op)?`)
+	regexBenchmark = regexp.MustCompile(`^(Benchmark[^ -]+)(?:-\d+\s+|\s+)(\d+)\s+(\d+|\d+\.\d+)\sns/op(?:\s+(\d+)\sB/op)?(?:\s+(\d+)\sallocs/op)?`)
 	regexOutput    = regexp.MustCompile(`(    )*\t(.*)`)
 	regexSummary   = regexp.MustCompile(`^(PASS|FAIL|SKIP)$`)
 )

--- a/testdata/28-bench-1cpu.txt
+++ b/testdata/28-bench-1cpu.txt
@@ -1,0 +1,4 @@
+pkg: single/cpu
+BenchmarkRing        	20000000	        74.2 ns/op
+PASS
+ok  	single/cpu	9.467s

--- a/testdata/28-report.xml
+++ b/testdata/28-report.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="1" failures="0" time="9.467" name="single/cpu">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="cpu" name="BenchmarkRing" time="0.000000074"></testcase>
+	</testsuite>
+</testsuites>

--- a/testdata/29-bench-16cpu.txt
+++ b/testdata/29-bench-16cpu.txt
@@ -1,0 +1,4 @@
+pkg: sixteen/cpu
+BenchmarkRingaround-16    	  100000	     13571 ns/op
+PASS
+ok  	sixteen/cpu	1.522s

--- a/testdata/29-report.xml
+++ b/testdata/29-report.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="1" failures="0" time="1.522" name="sixteen/cpu">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="cpu" name="BenchmarkRingaround" time="0.000013571"></testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
This fixes an issue encountered when trying to integrate benchmarks into our Jenkins jobs, which runs on different hosts.

Locally the benchmark result looks like
`BenchmarkRingValue-8          	30000000	        45.7 ns/op`  

On Jenkins it was
`BenchmarkRingValue-16          	30000000	        45.7 ns/op`

This PR changes `regexBenchmark` slightly so it is a little more flexible around capturing the Benchmark name to account for this.

Issue #74 