### PR TITLE
Reject positional CLI arguments

### DIFF
--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -26,6 +26,11 @@ func init() {
 func main() {
 	flag.Parse()
 
+	if flag.NArg() != 0 {
+		fmt.Println("go-junit-report does not accept positional arguments")
+		os.Exit(1)
+	}
+
 	// Read input
 	report, err := parser.Parse(os.Stdin, packageName)
 	if err != nil {


### PR DESCRIPTION
My team spent a bit of time debugging a mistake where we forgot to
redirect output to a file. The command looked valid and exited 0. This
change causes the program to fail if provided with any positional
arguments.