### PR TITLE
Failed test logging messages carried over buffers from all other runs successful and failing both

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Go version 1.1 or higher is required. Install or update using the `go get`
 command:
 
 ```bash
-go get -u github.com/jstemmer/go-junit-report
+go get -u github.com/orbs-network/go-junit-report
 ```
 
 ## Contribution
 
 Create an Issue and discuss the fix or feature, then fork the package.
-Clone to github.com/jstemmer/go-junit-report.  This is necessary because go import uses this path.
+Clone to github.com/orbs-network/go-junit-report.  This is necessary because go import uses this path.
 Fix or implement feature. Test and then commit change.
 Specify #Issue and describe change in the commit message.
 Create Pull Request. It can be merged by owner or administrator then.
@@ -40,7 +40,7 @@ Note that it also can parse benchmark output with `-bench` flag:
 go test -v -bench . -count 5 2>&1 | go-junit-report > report.xml
  ```
 
-[travis-badge]: https://travis-ci.org/jstemmer/go-junit-report.svg
-[travis-link]: https://travis-ci.org/jstemmer/go-junit-report
-[report-badge]: https://goreportcard.com/badge/github.com/jstemmer/go-junit-report
-[report-link]: https://goreportcard.com/report/github.com/jstemmer/go-junit-report
+[travis-badge]: https://travis-ci.org/orbs-network/go-junit-report.svg
+[travis-link]: https://travis-ci.org/orbs-network/go-junit-report
+[report-badge]: https://goreportcard.com/badge/github.com/orbs-network/go-junit-report
+[report-link]: https://goreportcard.com/report/github.com/orbs-network/go-junit-report

--- a/count_test.go
+++ b/count_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestFoo(t *testing.T) {
+	t.Log("foo")
+	t.Log("bar")
+	if rand.Int()%2 == 0 {
+		t.Errorf("test failed due to even number rand")
+	}
+}

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jstemmer/go-junit-report/parser"
+	"github.com/orbs-network/go-junit-report/parser"
 )
 
 // JUnitTestSuites is a collection of JUnit test suites.

--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jstemmer/go-junit-report/formatter"
-	"github.com/jstemmer/go-junit-report/parser"
+	"github.com/orbs-network/go-junit-report/formatter"
+	"github.com/orbs-network/go-junit-report/parser"
 )
 
 var (

--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"github.com/orbs-network/go-junit-report/formatter"
+	"github.com/orbs-network/go-junit-report/parser"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -11,9 +13,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/jstemmer/go-junit-report/formatter"
-	"github.com/jstemmer/go-junit-report/parser"
 )
 
 var matchTest = flag.String("match", "", "only test testdata matching this pattern")
@@ -1425,6 +1424,57 @@ var testCases = []TestCase{
 			},
 		},
 	},
+	{
+		name:       "31-repeated-names-with-log.txt",
+		reportName: "31-report.xml",
+		packageName: "foo",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name:     "github.com/orbs-network/go-junit-report",
+					Duration: 5 * time.Millisecond,
+					Time:     5,
+					Tests: []*parser.Test{
+						{
+							Name:     "TestFoo",
+							Duration: 0,
+							Time:     0,
+							Result:   parser.FAIL,
+							Output: []string{
+								"count_test.go:9: foo",
+								"count_test.go:10: bar",
+								"count_test.go:12: test failed due to even number rand",
+							},
+						},
+						{
+							Name:     "TestFoo",
+							Duration: 0,
+							Time:     0,
+							Result:   parser.PASS,
+							Output:   []string{},
+						}, {
+							Name:     "TestFoo",
+							Duration: 0,
+							Time:     0,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+						{
+							Name:     "TestFoo",
+							Duration: 0,
+							Time:     0,
+							Result:   parser.FAIL,
+							Output: []string{
+								"count_test.go:9: foo",
+								"count_test.go:10: bar",
+								"count_test.go:12: test failed due to even number rand",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestParser(t *testing.T) {
@@ -1547,7 +1597,7 @@ func testJUnitFormatter(t *testing.T, goVersion string) {
 			continue
 		}
 
-		report, err := loadTestReport(testCase.reportName, goVersion)
+		expectedReport, err := loadTestReport(testCase.reportName, goVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1558,8 +1608,9 @@ func testJUnitFormatter(t *testing.T, goVersion string) {
 			t.Fatal(err)
 		}
 
-		if string(junitReport.Bytes()) != report {
-			t.Errorf("Fail: %s Report xml ==\n%s, want\n%s", testCase.name, string(junitReport.Bytes()), report)
+		strReport := string(junitReport.Bytes())
+		if strReport != expectedReport {
+			t.Errorf("Fail: %s Report xml ==\n%s, want\n%s", testCase.name, strReport, expectedReport)
 		}
 	}
 }

--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -1425,8 +1425,8 @@ var testCases = []TestCase{
 		},
 	},
 	{
-		name:       "31-repeated-names-with-log.txt",
-		reportName: "31-report.xml",
+		name:        "31-repeated-names-with-log.txt",
+		reportName:  "31-report.xml",
 		packageName: "foo",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -1451,13 +1451,15 @@ var testCases = []TestCase{
 							Duration: 0,
 							Time:     0,
 							Result:   parser.PASS,
-							Output:   []string{},
+							Output: []string{"count_test.go:9: foo",
+								"count_test.go:10: bar"},
 						}, {
 							Name:     "TestFoo",
 							Duration: 0,
 							Time:     0,
 							Result:   parser.PASS,
-							Output:   []string{},
+							Output: []string{"count_test.go:9: foo",
+								"count_test.go:10: bar"},
 						},
 						{
 							Name:     "TestFoo",

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -128,6 +128,8 @@ func Parse(r io.Reader, pkgName string) (*Report, error) {
 			// clear the current build package, so output lines won't be added to that build
 			capturedPackage = ""
 			seenSummary = false
+			delete(buffers, cur)
+
 		} else if matches := regexBenchmark.FindStringSubmatch(line); len(matches) == 6 {
 			bytes, _ := strconv.Atoi(matches[4])
 			allocs, _ := strconv.Atoi(matches[5])

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -128,7 +128,7 @@ func Parse(r io.Reader, pkgName string) (*Report, error) {
 			// clear the current build package, so output lines won't be added to that build
 			capturedPackage = ""
 			seenSummary = false
-			delete(buffers, cur)
+			buffers[cur] = []string{}
 
 		} else if matches := regexBenchmark.FindStringSubmatch(line); len(matches) == 6 {
 			bytes, _ := strconv.Atoi(matches[4])

--- a/testdata/31-repeated-names-with-log.txt
+++ b/testdata/31-repeated-names-with-log.txt
@@ -1,0 +1,21 @@
+=== RUN   TestFoo
+--- FAIL: TestFoo (0.00s)
+    count_test.go:9: foo
+    count_test.go:10: bar
+    count_test.go:12: test failed due to even number rand
+=== RUN   TestFoo
+--- PASS: TestFoo (0.00s)
+    count_test.go:9: foo
+    count_test.go:10: bar
+=== RUN   TestFoo
+--- PASS: TestFoo (0.00s)
+    count_test.go:9: foo
+    count_test.go:10: bar
+=== RUN   TestFoo
+--- FAIL: TestFoo (0.00s)
+    count_test.go:9: foo
+    count_test.go:10: bar
+    count_test.go:12: test failed due to even number rand
+FAIL
+exit status 1
+FAIL	github.com/orbs-network/go-junit-report	0.005s

--- a/testdata/31-report.xml
+++ b/testdata/31-report.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="4" failures="2" time="0.005" name="github.com/orbs-network/go-junit-report">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="go-junit-report" name="TestFoo" time="0.000">
+			<failure message="Failed" type="">count_test.go:9: foo&#xA;count_test.go:10: bar&#xA;count_test.go:12: test failed due to even number rand</failure>
+		</testcase>
+		<testcase classname="go-junit-report" name="TestFoo" time="0.000"></testcase>
+		<testcase classname="go-junit-report" name="TestFoo" time="0.000"></testcase>
+		<testcase classname="go-junit-report" name="TestFoo" time="0.000">
+			<failure message="Failed" type="">count_test.go:9: foo&#xA;count_test.go:10: bar&#xA;count_test.go:12: test failed due to even number rand</failure>
+		</testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
We use the `go-junit-report` in our Go project so that CircleCI will be able
to read and summarize our test results clearer

However, since our system logging is verbose and can generate tremendous amounts of logs
this is something that we struggle with and were hoping can be addressed and this PR composes our our solution to this bug which is a hugh time saver for us in terms of realizing what has gone wrong
with a given test

In addition, (specifically to our case anyway) this helps us reduce the total build time since our log artifacts are much smaller now since they don't need to contain massive amount of unused logs