### PR TITLE
Output full classname as testcase classname attribute value

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -76,9 +76,6 @@ func JUnitReportXML(report *parser.Report, noXMLHeader bool, goVersion string, w
 		}
 
 		classname := pkg.Name
-		if idx := strings.LastIndex(classname, "/"); idx > -1 && idx < len(pkg.Name) {
-			classname = pkg.Name[idx+1:]
-		}
 
 		// properties
 		if goVersion == "" {

--- a/testdata/01-report.xml
+++ b/testdata/01-report.xml
@@ -4,7 +4,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestZ" time="0.060"></testcase>
-		<testcase classname="name" name="TestA" time="0.100"></testcase>
+		<testcase classname="package/name" name="TestZ" time="0.060"></testcase>
+		<testcase classname="package/name" name="TestA" time="0.100"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/02-report.xml
+++ b/testdata/02-report.xml
@@ -4,9 +4,9 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestOne" time="0.020">
+		<testcase classname="package/name" name="TestOne" time="0.020">
 			<failure message="Failed" type="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;&#x9;error&#xA;&#x9;message.</failure>
 		</testcase>
-		<testcase classname="name" name="TestTwo" time="0.130"></testcase>
+		<testcase classname="package/name" name="TestTwo" time="0.130"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/03-report.xml
+++ b/testdata/03-report.xml
@@ -4,9 +4,9 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestOne" time="0.020">
+		<testcase classname="package/name" name="TestOne" time="0.020">
 			<skipped message="file_test.go:11: Skip message"></skipped>
 		</testcase>
-		<testcase classname="name" name="TestTwo" time="0.130"></testcase>
+		<testcase classname="package/name" name="TestTwo" time="0.130"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/04-report.xml
+++ b/testdata/04-report.xml
@@ -4,7 +4,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestOne" time="0.060"></testcase>
-		<testcase classname="name" name="TestTwo" time="0.100"></testcase>
+		<testcase classname="package/name" name="TestOne" time="0.060"></testcase>
+		<testcase classname="package/name" name="TestTwo" time="0.100"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/05-report.xml
+++ b/testdata/05-report.xml
@@ -3,7 +3,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestOne" time="0.060"></testcase>
-		<testcase classname="name" name="TestTwo" time="0.100"></testcase>
+		<testcase classname="package/name" name="TestOne" time="0.060"></testcase>
+		<testcase classname="package/name" name="TestTwo" time="0.100"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/06-report.xml
+++ b/testdata/06-report.xml
@@ -3,16 +3,16 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name1" name="TestOne" time="0.060"></testcase>
-		<testcase classname="name1" name="TestTwo" time="0.100"></testcase>
+		<testcase classname="package/name1" name="TestOne" time="0.060"></testcase>
+		<testcase classname="package/name1" name="TestTwo" time="0.100"></testcase>
 	</testsuite>
 	<testsuite tests="2" failures="1" time="0.151" name="package/name2">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name2" name="TestOne" time="0.020">
+		<testcase classname="package/name2" name="TestOne" time="0.020">
 			<failure message="Failed" type="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;&#x9;error&#xA;&#x9;message.</failure>
 		</testcase>
-		<testcase classname="name2" name="TestTwo" time="0.130"></testcase>
+		<testcase classname="package/name2" name="TestTwo" time="0.130"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/07-report.xml
+++ b/testdata/07-report.xml
@@ -4,7 +4,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="package" name="TestOne" time="0.060"></testcase>
-		<testcase classname="package" name="TestTwo" time="0.100"></testcase>
+		<testcase classname="test/package" name="TestOne" time="0.060"></testcase>
+		<testcase classname="test/package" name="TestTwo" time="0.100"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/08-report.xml
+++ b/testdata/08-report.xml
@@ -4,7 +4,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="test-go-junit-report" name="TestDoFoo" time="0.270"></testcase>
-		<testcase classname="test-go-junit-report" name="TestDoFoo2" time="0.160"></testcase>
+		<testcase classname="github.com/dmitris/test-go-junit-report" name="TestDoFoo" time="0.270"></testcase>
+		<testcase classname="github.com/dmitris/test-go-junit-report" name="TestDoFoo2" time="0.160"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/09-report.xml
+++ b/testdata/09-report.xml
@@ -5,7 +5,7 @@
 			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="13.37"></property>
 		</properties>
-		<testcase classname="name" name="TestZ" time="0.060"></testcase>
-		<testcase classname="name" name="TestA" time="0.100"></testcase>
+		<testcase classname="package/name" name="TestZ" time="0.060"></testcase>
+		<testcase classname="package/name" name="TestA" time="0.100"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/10-report.xml
+++ b/testdata/10-report.xml
@@ -5,14 +5,14 @@
 			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="10.0"></property>
 		</properties>
-		<testcase classname="foo" name="TestA" time="0.100"></testcase>
-		<testcase classname="foo" name="TestB" time="0.300"></testcase>
+		<testcase classname="package1/foo" name="TestA" time="0.100"></testcase>
+		<testcase classname="package1/foo" name="TestB" time="0.300"></testcase>
 	</testsuite>
 	<testsuite tests="1" failures="0" time="4.200" name="package2/bar">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="99.8"></property>
 		</properties>
-		<testcase classname="bar" name="TestC" time="4.200"></testcase>
+		<testcase classname="package2/bar" name="TestC" time="4.200"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/11-report.xml
+++ b/testdata/11-report.xml
@@ -4,7 +4,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestOne" time="0.020"></testcase>
-		<testcase classname="name" name="TestTwo" time="0.030"></testcase>
+		<testcase classname="package/name" name="TestOne" time="0.020"></testcase>
+		<testcase classname="package/name" name="TestTwo" time="0.030"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/12-report.xml
+++ b/testdata/12-report.xml
@@ -4,32 +4,32 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestOne" time="0.010"></testcase>
-		<testcase classname="name" name="TestOne/Child" time="0.020"></testcase>
-		<testcase classname="name" name="TestOne/Child#01" time="0.030"></testcase>
-		<testcase classname="name" name="TestOne/Child=02" time="0.040"></testcase>
-		<testcase classname="name" name="TestTwo" time="0.010"></testcase>
-		<testcase classname="name" name="TestTwo/Child" time="0.020"></testcase>
-		<testcase classname="name" name="TestTwo/Child#01" time="0.030"></testcase>
-		<testcase classname="name" name="TestTwo/Child=02" time="0.040"></testcase>
-		<testcase classname="name" name="TestThree" time="0.010"></testcase>
-		<testcase classname="name" name="TestThree/a#1" time="0.020"></testcase>
-		<testcase classname="name" name="TestThree/a#1/b#1" time="0.030"></testcase>
-		<testcase classname="name" name="TestThree/a#1/b#1/c#1" time="0.040"></testcase>
-		<testcase classname="name" name="TestFour" time="0.020">
+		<testcase classname="package/name" name="TestOne" time="0.010"></testcase>
+		<testcase classname="package/name" name="TestOne/Child" time="0.020"></testcase>
+		<testcase classname="package/name" name="TestOne/Child#01" time="0.030"></testcase>
+		<testcase classname="package/name" name="TestOne/Child=02" time="0.040"></testcase>
+		<testcase classname="package/name" name="TestTwo" time="0.010"></testcase>
+		<testcase classname="package/name" name="TestTwo/Child" time="0.020"></testcase>
+		<testcase classname="package/name" name="TestTwo/Child#01" time="0.030"></testcase>
+		<testcase classname="package/name" name="TestTwo/Child=02" time="0.040"></testcase>
+		<testcase classname="package/name" name="TestThree" time="0.010"></testcase>
+		<testcase classname="package/name" name="TestThree/a#1" time="0.020"></testcase>
+		<testcase classname="package/name" name="TestThree/a#1/b#1" time="0.030"></testcase>
+		<testcase classname="package/name" name="TestThree/a#1/b#1/c#1" time="0.040"></testcase>
+		<testcase classname="package/name" name="TestFour" time="0.020">
 			<failure message="Failed" type=""></failure>
 		</testcase>
-		<testcase classname="name" name="TestFour/#00" time="0.000">
+		<testcase classname="package/name" name="TestFour/#00" time="0.000">
 			<failure message="Failed" type="">example.go:12: Expected abc  OBTAINED:&#xA;&#x9;xyz&#xA;example.go:123: Expected and obtained are different.</failure>
 		</testcase>
-		<testcase classname="name" name="TestFour/#01" time="0.000">
+		<testcase classname="package/name" name="TestFour/#01" time="0.000">
 			<skipped message="example.go:1234: Not supported yet."></skipped>
 		</testcase>
-		<testcase classname="name" name="TestFour/#02" time="0.000"></testcase>
-		<testcase classname="name" name="TestFive" time="0.000">
+		<testcase classname="package/name" name="TestFour/#02" time="0.000"></testcase>
+		<testcase classname="package/name" name="TestFive" time="0.000">
 			<skipped message="example.go:1392: Not supported yet."></skipped>
 		</testcase>
-		<testcase classname="name" name="TestSix" time="0.000">
+		<testcase classname="package/name" name="TestSix" time="0.000">
 			<failure message="Failed" type="">example.go:371: This should not fail!</failure>
 		</testcase>
 	</testsuite>

--- a/testdata/13-report.xml
+++ b/testdata/13-report.xml
@@ -4,19 +4,19 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="passing1" name="TestA" time="0.100"></testcase>
+		<testcase classname="package/name/passing1" name="TestA" time="0.100"></testcase>
 	</testsuite>
 	<testsuite tests="1" failures="0" time="0.100" name="package/name/passing2">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="passing2" name="TestB" time="0.100"></testcase>
+		<testcase classname="package/name/passing2" name="TestB" time="0.100"></testcase>
 	</testsuite>
 	<testsuite tests="1" failures="1" time="0.000" name="package/name/failing1">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="failing1" name="[build failed]" time="0.000">
+		<testcase classname="package/name/failing1" name="[build failed]" time="0.000">
 			<failure message="Failed" type="">failing1/failing_test.go:15: undefined: x</failure>
 		</testcase>
 	</testsuite>
@@ -24,7 +24,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="failing2" name="[build failed]" time="0.000">
+		<testcase classname="package/name/failing2" name="[build failed]" time="0.000">
 			<failure message="Failed" type="">failing2/another_failing_test.go:20: undefined: y</failure>
 		</testcase>
 	</testsuite>
@@ -32,7 +32,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="setupfailing1" name="[setup failed]" time="0.000">
+		<testcase classname="package/name/setupfailing1" name="[setup failed]" time="0.000">
 			<failure message="Failed" type="">setupfailing1/failing_test.go:4: cannot find package &#34;other/package&#34; in any of:&#xA;&#x9;/path/vendor (vendor tree)&#xA;&#x9;/path/go/root (from $GOROOT)&#xA;&#x9;/path/go/path (from $GOPATH)</failure>
 		</testcase>
 	</testsuite>

--- a/testdata/14-report.xml
+++ b/testdata/14-report.xml
@@ -4,7 +4,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="panic" name="Failure" time="0.000">
+		<testcase classname="package/panic" name="Failure" time="0.000">
 			<failure message="Failed" type="">panic: init&#xA;stacktrace</failure>
 		</testcase>
 	</testsuite>
@@ -12,7 +12,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="panic2" name="Failure" time="0.000">
+		<testcase classname="package/panic2" name="Failure" time="0.000">
 			<failure message="Failed" type="">panic: init&#xA;stacktrace</failure>
 		</testcase>
 	</testsuite>

--- a/testdata/16-report.xml
+++ b/testdata/16-report.xml
@@ -4,8 +4,8 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="repeated-names" name="TestRepeat" time="0.000"></testcase>
-		<testcase classname="repeated-names" name="TestRepeat" time="0.000"></testcase>
-		<testcase classname="repeated-names" name="TestRepeat" time="0.000"></testcase>
+		<testcase classname="package/repeated-names" name="TestRepeat" time="0.000"></testcase>
+		<testcase classname="package/repeated-names" name="TestRepeat" time="0.000"></testcase>
+		<testcase classname="package/repeated-names" name="TestRepeat" time="0.000"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/18-report.xml
+++ b/testdata/18-report.xml
@@ -5,14 +5,14 @@
 			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="10.0"></property>
 		</properties>
-		<testcase classname="foo" name="TestA" time="0.100"></testcase>
-		<testcase classname="foo" name="TestB" time="0.300"></testcase>
+		<testcase classname="package1/foo" name="TestA" time="0.100"></testcase>
+		<testcase classname="package1/foo" name="TestB" time="0.300"></testcase>
 	</testsuite>
 	<testsuite tests="1" failures="0" time="4.200" name="package2/bar">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="99.8"></property>
 		</properties>
-		<testcase classname="bar" name="TestC" time="4.200"></testcase>
+		<testcase classname="package2/bar" name="TestC" time="4.200"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/19-report.xml
+++ b/testdata/19-report.xml
@@ -4,7 +4,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name" name="TestZ" time="0.060"></testcase>
-		<testcase classname="name" name="TestA" time="0.100"></testcase>
+		<testcase classname="package/name" name="TestZ" time="0.060"></testcase>
+		<testcase classname="package/name" name="TestA" time="0.100"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/20-report.xml
+++ b/testdata/20-report.xml
@@ -4,13 +4,13 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="parallel" name="FirstTest" time="2.000">
+		<testcase classname="pkg/parallel" name="FirstTest" time="2.000">
 			<failure message="Failed" type="">Message from first&#xA;Supplemental from first&#xA;parallel_test.go:14: FirstTest error</failure>
 		</testcase>
-		<testcase classname="parallel" name="SecondTest" time="1.000">
+		<testcase classname="pkg/parallel" name="SecondTest" time="1.000">
 			<failure message="Failed" type="">Message from second&#xA;parallel_test.go:23: SecondTest error</failure>
 		</testcase>
-		<testcase classname="parallel" name="ThirdTest" time="0.010">
+		<testcase classname="pkg/parallel" name="ThirdTest" time="0.010">
 			<failure message="Failed" type="">Message from third&#xA;parallel_test.go:32: ThirdTest error</failure>
 		</testcase>
 	</testsuite>

--- a/testdata/21-report.xml
+++ b/testdata/21-report.xml
@@ -4,6 +4,6 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="one" name="TestOne" time="0.000"></testcase>
+		<testcase classname="package/one" name="TestOne" time="0.000"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/22-report.xml
+++ b/testdata/22-report.xml
@@ -4,7 +4,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="basic" name="BenchmarkParse" time="0.000000604"></testcase>
-		<testcase classname="basic" name="BenchmarkReadingList" time="0.000001425"></testcase>
+		<testcase classname="package/basic" name="BenchmarkParse" time="0.000000604"></testcase>
+		<testcase classname="package/basic" name="BenchmarkReadingList" time="0.000001425"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/23-report.xml
+++ b/testdata/23-report.xml
@@ -4,7 +4,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="one" name="BenchmarkIpsHistoryInsert" time="0.000052568"></testcase>
-		<testcase classname="one" name="BenchmarkIpsHistoryLookup" time="0.000015208"></testcase>
+		<testcase classname="package/one" name="BenchmarkIpsHistoryInsert" time="0.000052568"></testcase>
+		<testcase classname="package/one" name="BenchmarkIpsHistoryLookup" time="0.000015208"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/24-report.xml
+++ b/testdata/24-report.xml
@@ -4,11 +4,11 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="baz" name="TestNew" time="0.000"></testcase>
-		<testcase classname="baz" name="TestNew/no" time="0.000"></testcase>
-		<testcase classname="baz" name="TestNew/normal" time="0.000"></testcase>
-		<testcase classname="baz" name="TestWriteThis" time="0.000"></testcase>
-		<testcase classname="baz" name="BenchmarkDeepMerge" time="0.000002611"></testcase>
-		<testcase classname="baz" name="BenchmarkNext" time="0.000000100"></testcase>
+		<testcase classname="package3/baz" name="TestNew" time="0.000"></testcase>
+		<testcase classname="package3/baz" name="TestNew/no" time="0.000"></testcase>
+		<testcase classname="package3/baz" name="TestNew/normal" time="0.000"></testcase>
+		<testcase classname="package3/baz" name="TestWriteThis" time="0.000"></testcase>
+		<testcase classname="package3/baz" name="BenchmarkDeepMerge" time="0.000002611"></testcase>
+		<testcase classname="package3/baz" name="BenchmarkNext" time="0.000000100"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/25-report.xml
+++ b/testdata/25-report.xml
@@ -4,7 +4,7 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="count" name="BenchmarkNew" time="0.000000352"></testcase>
-		<testcase classname="count" name="BenchmarkFew" time="0.000000102"></testcase>
+		<testcase classname="pkg/count" name="BenchmarkNew" time="0.000000352"></testcase>
+		<testcase classname="pkg/count" name="BenchmarkFew" time="0.000000102"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/26-report.xml
+++ b/testdata/26-report.xml
@@ -4,16 +4,16 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="common" name="BenchmarkParse" time="0.000001591"></testcase>
-		<testcase classname="common" name="BenchmarkNewTask" time="0.000000391"></testcase>
+		<testcase classname="mycode/common" name="BenchmarkParse" time="0.000001591"></testcase>
+		<testcase classname="mycode/common" name="BenchmarkNewTask" time="0.000000391"></testcase>
 	</testsuite>
 	<testsuite tests="4" failures="0" time="47.084" name="mycode/benchmarks/channels">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="channels" name="BenchmarkFanout/Channel/10" time="0.000004673"></testcase>
-		<testcase classname="channels" name="BenchmarkFanout/Channel/100" time="0.000024965"></testcase>
-		<testcase classname="channels" name="BenchmarkFanout/Channel/1000" time="0.000195672"></testcase>
-		<testcase classname="channels" name="BenchmarkFanout/Channel/10000" time="0.002410200"></testcase>
+		<testcase classname="mycode/benchmarks/channels" name="BenchmarkFanout/Channel/10" time="0.000004673"></testcase>
+		<testcase classname="mycode/benchmarks/channels" name="BenchmarkFanout/Channel/100" time="0.000024965"></testcase>
+		<testcase classname="mycode/benchmarks/channels" name="BenchmarkFanout/Channel/1000" time="0.000195672"></testcase>
+		<testcase classname="mycode/benchmarks/channels" name="BenchmarkFanout/Channel/10000" time="0.002410200"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/27-report.xml
+++ b/testdata/27-report.xml
@@ -4,8 +4,8 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="small" name="BenchmarkItsy" time="0.000000045"></testcase>
-		<testcase classname="small" name="BenchmarkTeeny" time="0.000000002"></testcase>
-		<testcase classname="small" name="BenchmarkWeeny" time="0.000000000"></testcase>
+		<testcase classname="really/small" name="BenchmarkItsy" time="0.000000045"></testcase>
+		<testcase classname="really/small" name="BenchmarkTeeny" time="0.000000002"></testcase>
+		<testcase classname="really/small" name="BenchmarkWeeny" time="0.000000000"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/28-report.xml
+++ b/testdata/28-report.xml
@@ -4,6 +4,6 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="cpu" name="BenchmarkRing" time="0.000000074"></testcase>
+		<testcase classname="single/cpu" name="BenchmarkRing" time="0.000000074"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/29-report.xml
+++ b/testdata/29-report.xml
@@ -4,6 +4,6 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="cpu" name="BenchmarkRingaround" time="0.000013571"></testcase>
+		<testcase classname="sixteen/cpu" name="BenchmarkRingaround" time="0.000013571"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/30-report.xml
+++ b/testdata/30-report.xml
@@ -4,40 +4,40 @@
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="name1" name="TestFailWithStdoutAndTestOutput" time="0.100">
+		<testcase classname="package/name1" name="TestFailWithStdoutAndTestOutput" time="0.100">
 			<failure message="Failed" type="">multi&#xA;line&#xA;stdout&#xA;single-line stdout&#xA;example_test.go:13: single-line error&#xA;example_test.go:14: multi&#xA;    line&#xA;    error</failure>
 		</testcase>
-		<testcase classname="name1" name="TestFailWithStdoutAndNoTestOutput" time="0.150">
+		<testcase classname="package/name1" name="TestFailWithStdoutAndNoTestOutput" time="0.150">
 			<failure message="Failed" type="">multi&#xA;line&#xA;stdout&#xA;single-line stdout</failure>
 		</testcase>
-		<testcase classname="name1" name="TestFailWithTestOutput" time="0.200">
+		<testcase classname="package/name1" name="TestFailWithTestOutput" time="0.200">
 			<failure message="Failed" type="">example_test.go:26: single-line error&#xA;example_test.go:27: multi&#xA;    line&#xA;    error</failure>
 		</testcase>
-		<testcase classname="name1" name="TestFailWithNoTestOutput" time="0.250">
+		<testcase classname="package/name1" name="TestFailWithNoTestOutput" time="0.250">
 			<failure message="Failed" type=""></failure>
 		</testcase>
-		<testcase classname="name1" name="TestPassWithStdoutAndTestOutput" time="0.300"></testcase>
-		<testcase classname="name1" name="TestPassWithStdoutAndNoTestOutput" time="0.350"></testcase>
-		<testcase classname="name1" name="TestPassWithTestOutput" time="0.400"></testcase>
-		<testcase classname="name1" name="TestPassWithNoTestOutput" time="0.500"></testcase>
-		<testcase classname="name1" name="TestSubtests" time="2.270">
+		<testcase classname="package/name1" name="TestPassWithStdoutAndTestOutput" time="0.300"></testcase>
+		<testcase classname="package/name1" name="TestPassWithStdoutAndNoTestOutput" time="0.350"></testcase>
+		<testcase classname="package/name1" name="TestPassWithTestOutput" time="0.400"></testcase>
+		<testcase classname="package/name1" name="TestPassWithNoTestOutput" time="0.500"></testcase>
+		<testcase classname="package/name1" name="TestSubtests" time="2.270">
 			<failure message="Failed" type=""></failure>
 		</testcase>
-		<testcase classname="name1" name="TestSubtests/TestFailWithStdoutAndTestOutput" time="0.100">
+		<testcase classname="package/name1" name="TestSubtests/TestFailWithStdoutAndTestOutput" time="0.100">
 			<failure message="Failed" type="">1 multi&#xA;line&#xA;stdout&#xA;1 single-line stdout&#xA;example_test.go:65: 1 single-line error&#xA;example_test.go:66: 1 multi&#xA;    line&#xA;    error</failure>
 		</testcase>
-		<testcase classname="name1" name="TestSubtests/TestFailWithStdoutAndNoTestOutput" time="0.150">
+		<testcase classname="package/name1" name="TestSubtests/TestFailWithStdoutAndNoTestOutput" time="0.150">
 			<failure message="Failed" type="">2 multi&#xA;line&#xA;stdout&#xA;2 single-line stdout</failure>
 		</testcase>
-		<testcase classname="name1" name="TestSubtests/TestFailWithTestOutput" time="0.200">
+		<testcase classname="package/name1" name="TestSubtests/TestFailWithTestOutput" time="0.200">
 			<failure message="Failed" type="">example_test.go:78: 3 single-line error&#xA;example_test.go:79: 3 multi&#xA;    line&#xA;    error</failure>
 		</testcase>
-		<testcase classname="name1" name="TestSubtests/TestFailWithNoTestOutput" time="0.250">
+		<testcase classname="package/name1" name="TestSubtests/TestFailWithNoTestOutput" time="0.250">
 			<failure message="Failed" type=""></failure>
 		</testcase>
-		<testcase classname="name1" name="TestSubtests/TestPassWithStdoutAndTestOutput" time="0.300"></testcase>
-		<testcase classname="name1" name="TestSubtests/TestPassWithStdoutAndNoTestOutput" time="0.350"></testcase>
-		<testcase classname="name1" name="TestSubtests/TestPassWithTestOutput" time="0.400"></testcase>
-		<testcase classname="name1" name="TestSubtests/TestPassWithNoTestOutput" time="0.500"></testcase>
+		<testcase classname="package/name1" name="TestSubtests/TestPassWithStdoutAndTestOutput" time="0.300"></testcase>
+		<testcase classname="package/name1" name="TestSubtests/TestPassWithStdoutAndNoTestOutput" time="0.350"></testcase>
+		<testcase classname="package/name1" name="TestSubtests/TestPassWithTestOutput" time="0.400"></testcase>
+		<testcase classname="package/name1" name="TestSubtests/TestPassWithNoTestOutput" time="0.500"></testcase>
 	</testsuite>
 </testsuites>


### PR DESCRIPTION
Output the full classname in the classname attribute of testcase elements, instead of a classname with the package name removed.

This is consistent with the description for the testcase classname attribute described in https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd ("Full class name for the class the test method is in.")