### PR TITLE
Adjust xml annotations to allow unmarshal of test suites

### DIFF
--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -14,8 +14,8 @@ import (
 
 // JUnitTestSuites is a collection of JUnit test suites.
 type JUnitTestSuites struct {
-	XMLName xml.Name `xml:"testsuites"`
-	Suites  []JUnitTestSuite
+	XMLName xml.Name         `xml:"testsuites"`
+	Suites  []JUnitTestSuite `xml:"testsuite"`
 }
 
 // JUnitTestSuite is a single JUnit test suite which may contain many
@@ -27,7 +27,7 @@ type JUnitTestSuite struct {
 	Time       string          `xml:"time,attr"`
 	Name       string          `xml:"name,attr"`
 	Properties []JUnitProperty `xml:"properties>property,omitempty"`
-	TestCases  []JUnitTestCase
+	TestCases  []JUnitTestCase `xml:"testcase"`
 }
 
 // JUnitTestCase is a single test case with its result.

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -1,0 +1,64 @@
+package formatter
+
+import (
+	"bytes"
+	"encoding/xml"
+	"testing"
+)
+
+func TestSuites_Unmarshal(t *testing.T) {
+	tests := []struct {
+		desc        string
+		suites      JUnitTestSuites
+		noXMLHeader bool
+		goVersion   string
+	}{
+		{
+			desc: "Suites should marshal back and forth",
+			suites: JUnitTestSuites{
+				Suites: []JUnitTestSuite{
+					{
+						Name: "suite1",
+						TestCases: []JUnitTestCase{
+							{Name: "test1-1"},
+							{Name: "test1-2"},
+						},
+					},
+					{
+						Name: "suite2",
+						TestCases: []JUnitTestCase{
+							{Name: "test2-1"},
+							{Name: "test2-2"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Test case: %v", test.desc)
+		initialBytes, err := xml.Marshal(test.suites)
+		if err != nil {
+			t.Fatalf("Expected no failure when generating xml; got %v", err)
+		}
+
+		var suites JUnitTestSuites
+		err = xml.Unmarshal(initialBytes, &suites)
+		if err != nil {
+			t.Fatalf("Expected no failure when unmarshaling; got %v", err)
+		}
+
+		newBytes, err := xml.Marshal(suites)
+		if err != nil {
+			t.Fatalf("Expected no failure when generating xml again; got %v", err)
+		}
+
+		if !bytes.Equal(newBytes, initialBytes) {
+			t.Errorf("Expected the same result when marshal/unmarshal/marshal. Expected\n%v\n\t but got\n%v",
+				string(initialBytes),
+				string(newBytes),
+			)
+		}
+	}
+}


### PR DESCRIPTION
The xml annotations currently used allow for marshalling of
the test suites but fail to unmarshal them because of the
lack of an xml annotation on the slice fields for test suites
and test cases.

By adding those annotations, these types can be more widely reused.

Fixes #92