### PR TITLE
Parse package name output when test binary name is included

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -1425,6 +1425,87 @@ var testCases = []TestCase{
 			},
 		},
 	},
+	{
+		name:       "31-syntax-error-test-binary.txt",
+		reportName: "31-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name:     "package/name/passing1",
+					Duration: 100 * time.Millisecond,
+					Time:     100,
+					Tests: []*parser.Test{
+						{
+							Name:     "TestA",
+							Duration: 100 * time.Millisecond,
+							Time:     100,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+					},
+				},
+				{
+					Name:     "package/name/passing2",
+					Duration: 100 * time.Millisecond,
+					Time:     100,
+					Tests: []*parser.Test{
+						{
+							Name:     "TestB",
+							Duration: 100 * time.Millisecond,
+							Time:     100,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+					},
+				},
+				{
+					Name: "package/name/failing1",
+					Tests: []*parser.Test{
+						{
+							Name:     "[build failed]",
+							Duration: 0,
+							Time:     0,
+							Result:   parser.FAIL,
+							Output: []string{
+								"failing1/failing_test.go:15: undefined: x",
+							},
+						},
+					},
+				},
+				{
+					Name: "package/name/failing2",
+					Tests: []*parser.Test{
+						{
+							Name:     "[build failed]",
+							Duration: 0,
+							Time:     0,
+							Result:   parser.FAIL,
+							Output: []string{
+								"failing2/another_failing_test.go:20: undefined: y",
+							},
+						},
+					},
+				},
+				{
+					Name: "package/name/setupfailing1",
+					Tests: []*parser.Test{
+						{
+							Name:     "[setup failed]",
+							Duration: 0,
+							Time:     0,
+							Result:   parser.FAIL,
+							Output: []string{
+								"setupfailing1/failing_test.go:4: cannot find package \"other/package\" in any of:",
+								"\t/path/vendor (vendor tree)",
+								"\t/path/go/root (from $GOROOT)",
+								"\t/path/go/path (from $GOPATH)",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestParser(t *testing.T) {

--- a/testdata/31-report.xml
+++ b/testdata/31-report.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="1" failures="0" time="0.100" name="package/name/passing1">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="passing1" name="TestA" time="0.100"></testcase>
+	</testsuite>
+	<testsuite tests="1" failures="0" time="0.100" name="package/name/passing2">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="passing2" name="TestB" time="0.100"></testcase>
+	</testsuite>
+	<testsuite tests="1" failures="1" time="0.000" name="package/name/failing1">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="failing1" name="[build failed]" time="0.000">
+			<failure message="Failed" type="">failing1/failing_test.go:15: undefined: x</failure>
+		</testcase>
+	</testsuite>
+	<testsuite tests="1" failures="1" time="0.000" name="package/name/failing2">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="failing2" name="[build failed]" time="0.000">
+			<failure message="Failed" type="">failing2/another_failing_test.go:20: undefined: y</failure>
+		</testcase>
+	</testsuite>
+	<testsuite tests="1" failures="1" time="0.000" name="package/name/setupfailing1">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="setupfailing1" name="[setup failed]" time="0.000">
+			<failure message="Failed" type="">setupfailing1/failing_test.go:4: cannot find package &#34;other/package&#34; in any of:&#xA;&#x9;/path/vendor (vendor tree)&#xA;&#x9;/path/go/root (from $GOROOT)&#xA;&#x9;/path/go/path (from $GOPATH)</failure>
+		</testcase>
+	</testsuite>
+</testsuites>

--- a/testdata/31-syntax-error-test-binary.txt
+++ b/testdata/31-syntax-error-test-binary.txt
@@ -1,0 +1,20 @@
+# package/name/failing1 [package/name/failing1.test]
+failing1/failing_test.go:15: undefined: x
+# package/name/failing2 [package/name/failing2.test]
+failing2/another_failing_test.go:20: undefined: y
+# package/name/setupfailing1 [package/name/setupfailing1.test]
+setupfailing1/failing_test.go:4: cannot find package "other/package" in any of:
+	/path/vendor (vendor tree)
+	/path/go/root (from $GOROOT)
+	/path/go/path (from $GOPATH)
+=== RUN TestA
+--- PASS: TestA (0.10 seconds)
+PASS
+ok      package/name/passing1 0.100s
+=== RUN TestB
+--- PASS: TestB (0.10 seconds)
+PASS
+ok      package/name/passing2 0.100s
+FAIL    package/name/failing1 [build failed]
+FAIL    package/name/failing2 [build failed]
+FAIL    package/name/setupfailing1 [setup failed]


### PR DESCRIPTION
Sometimes, the text after "# " shows the name of the test binary ("<package>.test") in addition to the package e.g.: `# package/name [package/name.test]`. This change ensures that the packages' build outputs are associated correctly in this case.
