### PR TITLE
Add Package Prefix option for report namespacing

### DIFF
--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -12,6 +12,7 @@ import (
 var (
 	noXMLHeader   = flag.Bool("no-xml-header", false, "do not print xml header")
 	packageName   = flag.String("package-name", "", "specify a package name (compiled test have no package name in output)")
+	packagePrefix = flag.String("package-prefix", "", "specify a package prefix that can be used to namespace a test suite")
 	goVersionFlag = flag.String("go-version", "", "specify the value to use for the go.version property in the generated XML")
 	setExitCode   = flag.Bool("set-exit-code", false, "set exit code to 1 if tests failed")
 )
@@ -30,6 +31,11 @@ func main() {
 	if err != nil {
 		fmt.Printf("Error reading input: %s\n", err)
 		os.Exit(1)
+	}
+
+	// Replace report with a version that has prefixed package names before formatting
+	if *packagePrefix != "" {
+		report = report.PrefixPackage(*packagePrefix)
 	}
 
 	// Write xml

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -317,3 +317,15 @@ func (r *Report) Failures() int {
 
 	return count
 }
+
+// PrefixPackage returns a copy of the given report, with the given prefix prepended to all package names.
+func (r *Report) PrefixPackage(prefix string) *Report {
+	reportCopy := Report{
+		Packages: make([]Package, len(r.Packages)),
+	}
+	for i, pkg := range r.Packages {
+		pkg.Name = prefix + pkg.Name
+		reportCopy.Packages[i] = pkg
+	}
+	return &reportCopy
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -42,6 +43,28 @@ func TestParseNanoseconds(t *testing.T) {
 		d := parseNanoseconds(test.in)
 		if d != test.d {
 			t.Errorf("parseSeconds(%q) == %v, want %v\n", test.in, d, test.d)
+		}
+	}
+}
+
+func TestReportPrefixPackage(t *testing.T) {
+	const prefix = "linux/amd64/"
+	originalReport := &Report{
+		Packages: []Package{
+			{Name: "pkg/a"},
+			{Name: "pkg/b"},
+			{Name: "pkg/c"},
+		},
+	}
+
+	prefixedReport := originalReport.PrefixPackage(prefix)
+
+	for i, pkg := range originalReport.Packages {
+		if strings.HasPrefix(pkg.Name, prefix) {
+			t.Errorf("expecting original report package %q not to be modified", pkg.Name)
+		}
+		if !strings.HasPrefix(prefixedReport.Packages[i].Name, prefix) {
+			t.Errorf("expecting prefixed report package %q to be prefixed with %q", pkg.Name, prefix)
 		}
 	}
 }

--- a/testdata/33-package-prefix.txt
+++ b/testdata/33-package-prefix.txt
@@ -1,0 +1,4 @@
+=== RUN   TestOne
+--- PASS: TestOne (0.00s)
+PASS
+ok	pkg/pass	0.005s

--- a/testdata/33-report.xml
+++ b/testdata/33-report.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="1" failures="0" time="0.005" name="linux/arm64/pkg/pass">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="pass" name="TestOne" time="0.000"></testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
Closes #100 

Adds a `-package-prefix` flag, that can be used to namespace packages in reports.

This opens up the opportunity to use go-junit-report to generate unique XML reports for various combinations of `$GOOS`/`$GOARCH` (and other build tags) that won't conflict with each other.

More detail about this use-case is included in #100

Example usage:
```sh
export GOOS=linux
export GOARCH=arm64
go test -v 2>&1 | go-junit-report -package-prefix="${GOOS}/${GOARCH}" > report-${GOOS}-${GOARCH}.xml
```