### PR TITLE
support go-acc output.(in go-acc output coverage data format is changed)

### DIFF
--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -326,7 +326,82 @@ var testCases = []TestCase{
 		},
 	},
 	{
+		name:       "09-coverage-acc.txt",
+		reportName: "09-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name:     "package/name",
+					Duration: 160 * time.Millisecond,
+					Time:     160,
+					Tests: []*parser.Test{
+						{
+							Name:     "TestZ",
+							Duration: 60 * time.Millisecond,
+							Time:     60,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+						{
+							Name:     "TestA",
+							Duration: 100 * time.Millisecond,
+							Time:     100,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+					},
+					CoveragePct: "13.37",
+				},
+			},
+		},
+	},
+	{
 		name:       "10-multipkg-coverage.txt",
+		reportName: "10-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name:     "package1/foo",
+					Duration: 400 * time.Millisecond,
+					Time:     400,
+					Tests: []*parser.Test{
+						{
+							Name:     "TestA",
+							Duration: 100 * time.Millisecond,
+							Time:     100,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+						{
+							Name:     "TestB",
+							Duration: 300 * time.Millisecond,
+							Time:     300,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+					},
+					CoveragePct: "10.0",
+				},
+				{
+					Name:     "package2/bar",
+					Duration: 4200 * time.Millisecond,
+					Time:     4200,
+					Tests: []*parser.Test{
+						{
+							Name:     "TestC",
+							Duration: 4200 * time.Millisecond,
+							Time:     4200,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+					},
+					CoveragePct: "99.8",
+				},
+			},
+		},
+	},
+	{
+		name:       "10-multipkg-coverage-acc.txt",
 		reportName: "10-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{
@@ -779,6 +854,51 @@ var testCases = []TestCase{
 	},
 	{
 		name:       "18-coverpkg.txt",
+		reportName: "18-report.xml",
+		report: &parser.Report{
+			Packages: []parser.Package{
+				{
+					Name:     "package1/foo",
+					Duration: 400 * time.Millisecond,
+					Time:     400,
+					Tests: []*parser.Test{
+						{
+							Name:     "TestA",
+							Duration: 100 * time.Millisecond,
+							Time:     100,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+						{
+							Name:     "TestB",
+							Duration: 300 * time.Millisecond,
+							Time:     300,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+					},
+					CoveragePct: "10.0",
+				},
+				{
+					Name:     "package2/bar",
+					Duration: 4200 * time.Millisecond,
+					Time:     4200,
+					Tests: []*parser.Test{
+						{
+							Name:     "TestC",
+							Duration: 4200 * time.Millisecond,
+							Time:     4200,
+							Result:   parser.PASS,
+							Output:   []string{},
+						},
+					},
+					CoveragePct: "99.8",
+				},
+			},
+		},
+	},
+	{
+		name:       "18-coverpkg-acc.txt",
 		reportName: "18-report.xml",
 		report: &parser.Report{
 			Packages: []parser.Package{

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/jstemmer/go-junit-report
 
 go 1.2
-
-replace github.com/jstemmer/go-junit-report => github.com/mrhjkim/go-junit-report v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/jstemmer/go-junit-report
 
 go 1.2
+
+replace github.com/jstemmer/go-junit-report => github.com/mrhjkim/go-junit-report v0.9.1

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -62,8 +62,8 @@ type Benchmark struct {
 var (
 	regexStatus   = regexp.MustCompile(`--- (PASS|FAIL|SKIP): (.+) \((\d+\.\d+)(?: seconds|s)\)`)
 	regexIndent   = regexp.MustCompile(`^([ \t]+)---`)
-	regexCoverage = regexp.MustCompile(`^coverage:\s+(\d+\.\d+)%\s+of\s+statements(?:\sin\s.+)?$`)
-	regexResult   = regexp.MustCompile(`^(ok|FAIL)\s+([^ ]+)\s+(?:(\d+\.\d+)s|\(cached\)|(\[\w+ failed]))(?:\s+coverage:\s+(\d+\.\d+)%\sof\sstatements(?:\sin\s.+)?)?$`)
+	regexCoverage = regexp.MustCompile(`^coverage:\s+(\d+\.\d+)(?:%\s+of\s+statements)?(?:\sin\s.+)?$`)
+	regexResult   = regexp.MustCompile(`^(ok|FAIL)\s+([^ ]+)\s+(?:(\d+\.\d+)s|\(cached\)|(\[\w+ failed]))(?:\s+coverage:\s+(\d+\.\d+)(?:%\sof\sstatements)?(?:\sin\s.+)?)?$`)
 	// regexBenchmark captures 3-5 groups: benchmark name, number of times ran, ns/op (with or without decimal), B/op (optional), and allocs/op (optional).
 	regexBenchmark       = regexp.MustCompile(`^(Benchmark[^ -]+)(?:-\d+\s+|\s+)(\d+)\s+(\d+|\d+\.\d+)\sns/op(?:\s+(\d+)\sB/op)?(?:\s+(\d+)\sallocs/op)?`)
 	regexOutput          = regexp.MustCompile(`(    )*\t(.*)`)

--- a/testdata/09-coverage-acc.txt
+++ b/testdata/09-coverage-acc.txt
@@ -1,0 +1,7 @@
+=== RUN TestZ
+--- PASS: TestZ (0.06 seconds)
+=== RUN TestA
+--- PASS: TestA (0.10 seconds)
+PASS
+coverage: 13.37
+ok  	package/name 0.160s

--- a/testdata/10-multipkg-coverage-acc.txt
+++ b/testdata/10-multipkg-coverage-acc.txt
@@ -1,0 +1,12 @@
+=== RUN TestA
+--- PASS: TestA (0.10 seconds)
+=== RUN TestB
+--- PASS: TestB (0.30 seconds)
+PASS
+coverage: 10
+ok  	package1/foo 0.400s  coverage: 10.0
+=== RUN TestC
+--- PASS: TestC (4.20 seconds)
+PASS
+coverage: 99.8
+ok  	package2/bar 4.200s  coverage: 99.8

--- a/testdata/18-coverpkg-acc.txt
+++ b/testdata/18-coverpkg-acc.txt
@@ -1,0 +1,12 @@
+=== RUN TestA
+--- PASS: TestA (0.10 seconds)
+=== RUN TestB
+--- PASS: TestB (0.30 seconds)
+PASS
+coverage: 10
+ok  	package1/foo 0.400s  coverage: 10.0
+=== RUN TestC
+--- PASS: TestC (4.20 seconds)
+PASS
+coverage: 99.8
+ok  	package2/bar 4.200s  coverage: 99.8


### PR DESCRIPTION
when using go-acc for accurate coverage report, it generate coverage related report differently without(% of statements ........)
=>original example
coverage: 10% of statements
ok  	package1/foo 0.400s  coverage: 10.0% of statements
=>go-acc output
coverage: 10
ok  	package1/foo 0.400s  coverage: 10.0

I changed regular expression to treat "% of statements" as optional

you can test go-acc with following commands
go get github.com/ory/go-acc
go-acc -o coverage.out ./... -- -v | go-junit-report