### PR TITLE
Include filepath flag support for loading gotest verbose output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,17 @@ go get -u github.com/jstemmer/go-junit-report
 
 ## Usage
 
-go-junit-report reads the `go test` verbose output from standard in and writes
+go-junit-report reads the `go test` verbose output from either standard in or file,and writes
 junit compatible XML to standard out.
-
-```bash
-go test -v 2>&1 | go-junit-report > report.xml
-```
-
+* Standard Input: 
+    ```bash
+    go test -v ./... 2>&1 | go-junit-report > report.xml
+    ```
+* File:
+    ```bash
+    go test -v ./... > gotest.out  
+    go-junit-report --go-test-output gotest.out > report.xml
+    ```
 Note that it also can parse benchmark output with `-bench` flag:
 ```bash
 go test -v -bench . -count 5 2>&1 | go-junit-report > report.xml

--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/jstemmer/go-junit-report/formatter"
@@ -14,19 +17,30 @@ var (
 	packageName   = flag.String("package-name", "", "specify a package name (compiled test have no package name in output)")
 	goVersionFlag = flag.String("go-version", "", "specify the value to use for the go.version property in the generated XML")
 	setExitCode   = flag.Bool("set-exit-code", false, "set exit code to 1 if tests failed")
+	goTestFile    = flag.String("go-test-output", "", "specify file containing the contents of gotest verbose execution")
 )
 
 func main() {
 	flag.Parse()
-
 	if flag.NArg() != 0 {
 		fmt.Fprintf(os.Stderr, "%s does not accept positional arguments\n", os.Args[0])
 		flag.Usage()
 		os.Exit(1)
 	}
 
+	var goTestOutputReader io.Reader
+	if goTestFilePath := *goTestFile; len(goTestFilePath) > 0 {
+		if content, readErr := ioutil.ReadFile(goTestFilePath); readErr != nil {
+			fmt.Printf("Error reading file[path= %s]: %s", goTestFilePath, readErr)
+			os.Exit(1)
+		} else {
+			goTestOutputReader = bytes.NewBuffer(content)
+		}
+	} else {
+		goTestOutputReader = os.Stdin
+	}
 	// Read input
-	report, err := parser.Parse(os.Stdin, *packageName)
+	report, err := parser.Parse(goTestOutputReader, *packageName)
 	if err != nil {
 		fmt.Printf("Error reading input: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Adding flag for supporting filepath entry for gotest verbose output, alternative input from os.Stdin (#1)