### PR TITLE
Enhance multi-line support, use errors, optional sub-test wrapper ignore

### DIFF
--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -10,10 +10,11 @@ import (
 )
 
 var (
-	noXMLHeader   = flag.Bool("no-xml-header", false, "do not print xml header")
-	packageName   = flag.String("package-name", "", "specify a package name (compiled test have no package name in output)")
-	goVersionFlag = flag.String("go-version", "", "specify the value to use for the go.version property in the generated XML")
-	setExitCode   = flag.Bool("set-exit-code", false, "set exit code to 1 if tests failed")
+	noXMLHeader          = flag.Bool("no-xml-header", false, "do not print xml header")
+	packageName          = flag.String("package-name", "", "specify a package name (compiled test have no package name in output)")
+	goVersionFlag        = flag.String("go-version", "", "specify the value to use for the go.version property in the generated XML")
+	ignoreSubtestParents = flag.Bool("ignore-parents", false, "exclude parents of sub tests in the generated XML")
+	setExitCode          = flag.Bool("set-exit-code", false, "set exit code to 1 if tests failed")
 )
 
 func main() {
@@ -26,7 +27,7 @@ func main() {
 	}
 
 	// Read input
-	report, err := parser.Parse(os.Stdin, *packageName)
+	report, err := parser.Parse(os.Stdin, *packageName, *ignoreSubtestParents)
 	if err != nil {
 		fmt.Printf("Error reading input: %s\n", err)
 		os.Exit(1)

--- a/testdata/01-report.xml
+++ b/testdata/01-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+	<testsuite tests="2" failures="0" errors="0" time="0.160" name="package/name">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/02-report.xml
+++ b/testdata/02-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="1" time="0.151" name="package/name">
+	<testsuite tests="2" failures="1" errors="0" time="0.151" name="package/name">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/03-report.xml
+++ b/testdata/03-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.150" name="package/name">
+	<testsuite tests="2" failures="0" errors="0" time="0.150" name="package/name">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/04-report.xml
+++ b/testdata/04-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+	<testsuite tests="2" failures="0" errors="0" time="0.160" name="package/name">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/05-report.xml
+++ b/testdata/05-report.xml
@@ -1,5 +1,5 @@
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+	<testsuite tests="2" failures="0" errors="0" time="0.160" name="package/name">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/06-report.xml
+++ b/testdata/06-report.xml
@@ -1,12 +1,12 @@
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="package/name1">
+	<testsuite tests="2" failures="0" errors="0" time="0.160" name="package/name1">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="name1" name="TestOne" time="0.060"></testcase>
 		<testcase classname="name1" name="TestTwo" time="0.100"></testcase>
 	</testsuite>
-	<testsuite tests="2" failures="1" time="0.151" name="package/name2">
+	<testsuite tests="2" failures="1" errors="0" time="0.151" name="package/name2">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/07-report.xml
+++ b/testdata/07-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="test/package">
+	<testsuite tests="2" failures="0" errors="0" time="0.160" name="test/package">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/08-report.xml
+++ b/testdata/08-report.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.440" name="github.com/dmitris/test-go-junit-report">
+	<testsuite tests="2" failures="0" errors="0" time="0.440" name="github.com/dmitris/test-go-junit-report">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="test-go-junit-report" name="TestDoFoo" time="0.270"></testcase>
-		<testcase classname="test-go-junit-report" name="TestDoFoo2" time="0.160"></testcase>
+		<testcase classname="test-go-junit-report" name="TestDoFoo" time="0.270" system-out="cov_test.go:10: DoFoo log 1&#xA;cov_test.go:10: DoFoo log 2"></testcase>
+		<testcase classname="test-go-junit-report" name="TestDoFoo2" time="0.160" system-out="cov_test.go:21: DoFoo2 log 1&#xA;cov_test.go:21: DoFoo2 log 2"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/09-report.xml
+++ b/testdata/09-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+	<testsuite tests="2" failures="0" errors="0" time="0.160" name="package/name">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="13.37"></property>

--- a/testdata/10-report.xml
+++ b/testdata/10-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.400" name="package1/foo">
+	<testsuite tests="2" failures="0" errors="0" time="0.400" name="package1/foo">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="10.0"></property>
@@ -8,7 +8,7 @@
 		<testcase classname="foo" name="TestA" time="0.100"></testcase>
 		<testcase classname="foo" name="TestB" time="0.300"></testcase>
 	</testsuite>
-	<testsuite tests="1" failures="0" time="4.200" name="package2/bar">
+	<testsuite tests="1" failures="0" errors="0" time="4.200" name="package2/bar">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="99.8"></property>

--- a/testdata/11-report.xml
+++ b/testdata/11-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.050" name="package/name">
+	<testsuite tests="2" failures="0" errors="0" time="0.050" name="package/name">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/12-report.xml
+++ b/testdata/12-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="18" failures="3" time="0.050" name="package/name">
+	<testsuite tests="18" failures="3" errors="0" time="0.050" name="package/name">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/13-report.xml
+++ b/testdata/13-report.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="1" failures="0" time="0.100" name="package/name/passing1">
+	<testsuite tests="1" failures="0" errors="0" time="0.100" name="package/name/passing1">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="passing1" name="TestA" time="0.100"></testcase>
 	</testsuite>
-	<testsuite tests="1" failures="0" time="0.100" name="package/name/passing2">
+	<testsuite tests="1" failures="0" errors="0" time="0.100" name="package/name/passing2">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="passing2" name="TestB" time="0.100"></testcase>
 	</testsuite>
-	<testsuite tests="1" failures="1" time="0.000" name="package/name/failing1">
+	<testsuite tests="1" failures="0" errors="1" time="0.000" name="package/name/failing1">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="failing1" name="[build failed]" time="0.000">
-			<failure message="Failed" type="">failing1/failing_test.go:15: undefined: x</failure>
+			<error message="Error" type="">failing1/failing_test.go:15: undefined: x</error>
 		</testcase>
 	</testsuite>
-	<testsuite tests="1" failures="1" time="0.000" name="package/name/failing2">
+	<testsuite tests="1" failures="0" errors="1" time="0.000" name="package/name/failing2">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="failing2" name="[build failed]" time="0.000">
-			<failure message="Failed" type="">failing2/another_failing_test.go:20: undefined: y</failure>
+			<error message="Error" type="">failing2/another_failing_test.go:20: undefined: y</error>
 		</testcase>
 	</testsuite>
-	<testsuite tests="1" failures="1" time="0.000" name="package/name/setupfailing1">
+	<testsuite tests="1" failures="0" errors="1" time="0.000" name="package/name/setupfailing1">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="setupfailing1" name="[setup failed]" time="0.000">
-			<failure message="Failed" type="">setupfailing1/failing_test.go:4: cannot find package &#34;other/package&#34; in any of:&#xA;&#x9;/path/vendor (vendor tree)&#xA;&#x9;/path/go/root (from $GOROOT)&#xA;&#x9;/path/go/path (from $GOPATH)</failure>
+			<error message="Error" type="">setupfailing1/failing_test.go:4: cannot find package &#34;other/package&#34; in any of:&#xA;&#x9;/path/vendor (vendor tree)&#xA;&#x9;/path/go/root (from $GOROOT)&#xA;&#x9;/path/go/path (from $GOPATH)</error>
 		</testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/14-report.xml
+++ b/testdata/14-report.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="1" failures="1" time="0.003" name="package/panic">
+	<testsuite tests="1" failures="0" errors="1" time="0.003" name="package/panic">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="panic" name="Failure" time="0.000">
-			<failure message="Failed" type="">panic: init&#xA;stacktrace</failure>
+		<testcase classname="panic" name="Error" time="0.000">
+			<error message="Error" type="">panic: init&#xA;stacktrace</error>
 		</testcase>
 	</testsuite>
-	<testsuite tests="1" failures="1" time="0.003" name="package/panic2">
+	<testsuite tests="1" failures="0" errors="1" time="0.003" name="package/panic2">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
-		<testcase classname="panic2" name="Failure" time="0.000">
-			<failure message="Failed" type="">panic: init&#xA;stacktrace</failure>
+		<testcase classname="panic2" name="Error" time="0.000">
+			<error message="Error" type="">panic: init&#xA;stacktrace</error>
 		</testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/15-report.xml
+++ b/testdata/15-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="0" failures="0" time="0.001" name="package/empty">
+	<testsuite tests="0" failures="0" errors="0" time="0.001" name="package/empty">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/16-report.xml
+++ b/testdata/16-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="3" failures="0" time="0.001" name="package/repeated-names">
+	<testsuite tests="3" failures="0" errors="0" time="0.001" name="package/repeated-names">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/17-report.xml
+++ b/testdata/17-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="1" failures="1" time="0.015" name="race_test">
+	<testsuite tests="1" failures="1" errors="0" time="0.015" name="race_test">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/18-report.xml
+++ b/testdata/18-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.400" name="package1/foo">
+	<testsuite tests="2" failures="0" errors="0" time="0.400" name="package1/foo">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="10.0"></property>
@@ -8,7 +8,7 @@
 		<testcase classname="foo" name="TestA" time="0.100"></testcase>
 		<testcase classname="foo" name="TestB" time="0.300"></testcase>
 	</testsuite>
-	<testsuite tests="1" failures="0" time="4.200" name="package2/bar">
+	<testsuite tests="1" failures="0" errors="0" time="4.200" name="package2/bar">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 			<property name="coverage.statements.pct" value="99.8"></property>

--- a/testdata/19-report.xml
+++ b/testdata/19-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="0.160" name="package/name">
+	<testsuite tests="2" failures="0" errors="0" time="0.160" name="package/name">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/20-report.xml
+++ b/testdata/20-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="3" failures="3" time="3.010" name="pkg/parallel">
+	<testsuite tests="3" failures="3" errors="0" time="3.010" name="pkg/parallel">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/21-report.xml
+++ b/testdata/21-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="1" failures="0" time="0.000" name="package/one">
+	<testsuite tests="1" failures="0" errors="0" time="0.000" name="package/one">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/22-report.xml
+++ b/testdata/22-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="3.212" name="package/basic">
+	<testsuite tests="2" failures="0" errors="0" time="3.212" name="package/basic">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/23-report.xml
+++ b/testdata/23-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="9.415" name="package/one">
+	<testsuite tests="2" failures="0" errors="0" time="9.415" name="package/one">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/24-report.xml
+++ b/testdata/24-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="6" failures="0" time="1.382" name="package3/baz">
+	<testsuite tests="6" failures="0" errors="0" time="1.382" name="package3/baz">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/25-report.xml
+++ b/testdata/25-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="14.211" name="pkg/count">
+	<testsuite tests="2" failures="0" errors="0" time="14.211" name="pkg/count">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/26-report.xml
+++ b/testdata/26-report.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="0" time="7.267" name="mycode/common">
+	<testsuite tests="2" failures="0" errors="0" time="7.267" name="mycode/common">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="common" name="BenchmarkParse" time="0.000001591"></testcase>
 		<testcase classname="common" name="BenchmarkNewTask" time="0.000000391"></testcase>
 	</testsuite>
-	<testsuite tests="4" failures="0" time="47.084" name="mycode/benchmarks/channels">
+	<testsuite tests="4" failures="0" errors="0" time="47.084" name="mycode/benchmarks/channels">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/27-report.xml
+++ b/testdata/27-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="3" failures="0" time="4.344" name="really/small">
+	<testsuite tests="3" failures="0" errors="0" time="4.344" name="really/small">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/28-report.xml
+++ b/testdata/28-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="1" failures="0" time="9.467" name="single/cpu">
+	<testsuite tests="1" failures="0" errors="0" time="9.467" name="single/cpu">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/29-report.xml
+++ b/testdata/29-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="1" failures="0" time="1.522" name="sixteen/cpu">
+	<testsuite tests="1" failures="0" errors="0" time="1.522" name="sixteen/cpu">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>

--- a/testdata/30-report.xml
+++ b/testdata/30-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="17" failures="9" time="4.567" name="package/name1">
+	<testsuite tests="17" failures="9" errors="0" time="4.567" name="package/name1">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
@@ -16,9 +16,9 @@
 		<testcase classname="name1" name="TestFailWithNoTestOutput" time="0.250">
 			<failure message="Failed" type=""></failure>
 		</testcase>
-		<testcase classname="name1" name="TestPassWithStdoutAndTestOutput" time="0.300"></testcase>
-		<testcase classname="name1" name="TestPassWithStdoutAndNoTestOutput" time="0.350"></testcase>
-		<testcase classname="name1" name="TestPassWithTestOutput" time="0.400"></testcase>
+		<testcase classname="name1" name="TestPassWithStdoutAndTestOutput" time="0.300" system-out="multi&#xA;line&#xA;stdout&#xA;single-line stdout&#xA;example_test.go:39: single-line info&#xA;example_test.go:40: multi&#xA;    line&#xA;    info"></testcase>
+		<testcase classname="name1" name="TestPassWithStdoutAndNoTestOutput" time="0.350" system-out="multi&#xA;line&#xA;stdout&#xA;single-line stdout"></testcase>
+		<testcase classname="name1" name="TestPassWithTestOutput" time="0.400" system-out="example_test.go:51: single-line info&#xA;example_test.go:52: multi&#xA;    line&#xA;    info"></testcase>
 		<testcase classname="name1" name="TestPassWithNoTestOutput" time="0.500"></testcase>
 		<testcase classname="name1" name="TestSubtests" time="2.270">
 			<failure message="Failed" type=""></failure>
@@ -35,9 +35,9 @@
 		<testcase classname="name1" name="TestSubtests/TestFailWithNoTestOutput" time="0.250">
 			<failure message="Failed" type=""></failure>
 		</testcase>
-		<testcase classname="name1" name="TestSubtests/TestPassWithStdoutAndTestOutput" time="0.300"></testcase>
-		<testcase classname="name1" name="TestSubtests/TestPassWithStdoutAndNoTestOutput" time="0.350"></testcase>
-		<testcase classname="name1" name="TestSubtests/TestPassWithTestOutput" time="0.400"></testcase>
+		<testcase classname="name1" name="TestSubtests/TestPassWithStdoutAndTestOutput" time="0.300" system-out="4 multi&#xA;line&#xA;stdout&#xA;4 single-line stdout&#xA;example_test.go:91: 4 single-line info&#xA;example_test.go:92: 4 multi&#xA;    line&#xA;    info"></testcase>
+		<testcase classname="name1" name="TestSubtests/TestPassWithStdoutAndNoTestOutput" time="0.350" system-out="5 multi&#xA;line&#xA;stdout&#xA;5 single-line stdout"></testcase>
+		<testcase classname="name1" name="TestSubtests/TestPassWithTestOutput" time="0.400" system-out="example_test.go:103: 6 single-line info&#xA;example_test.go:104: 6 multi&#xA;    line&#xA;    info"></testcase>
 		<testcase classname="name1" name="TestSubtests/TestPassWithNoTestOutput" time="0.500"></testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/31-report.xml
+++ b/testdata/31-report.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="1" failures="0" time="0.100" name="package/name/passing1">
+	<testsuite tests="1" failures="0" errors="0" time="0.100" name="package/name/passing1">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="passing1" name="TestA" time="0.100"></testcase>
 	</testsuite>
-	<testsuite tests="1" failures="0" time="0.100" name="package/name/passing2">
+	<testsuite tests="1" failures="0" errors="0" time="0.100" name="package/name/passing2">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="passing2" name="TestB" time="0.100"></testcase>
 	</testsuite>
-	<testsuite tests="1" failures="1" time="0.000" name="package/name/failing1">
+	<testsuite tests="1" failures="0" errors="1" time="0.000" name="package/name/failing1">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="failing1" name="[build failed]" time="0.000">
-			<failure message="Failed" type="">failing1/failing_test.go:15: undefined: x</failure>
+			<error message="Error" type="">failing1/failing_test.go:15: undefined: x</error>
 		</testcase>
 	</testsuite>
-	<testsuite tests="1" failures="1" time="0.000" name="package/name/failing2">
+	<testsuite tests="1" failures="0" errors="1" time="0.000" name="package/name/failing2">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="failing2" name="[build failed]" time="0.000">
-			<failure message="Failed" type="">failing2/another_failing_test.go:20: undefined: y</failure>
+			<error message="Error" type="">failing2/another_failing_test.go:20: undefined: y</error>
 		</testcase>
 	</testsuite>
-	<testsuite tests="1" failures="1" time="0.000" name="package/name/setupfailing1">
+	<testsuite tests="1" failures="0" errors="1" time="0.000" name="package/name/setupfailing1">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="setupfailing1" name="[setup failed]" time="0.000">
-			<failure message="Failed" type="">setupfailing1/failing_test.go:4: cannot find package &#34;other/package&#34; in any of:&#xA;&#x9;/path/vendor (vendor tree)&#xA;&#x9;/path/go/root (from $GOROOT)&#xA;&#x9;/path/go/path (from $GOPATH)</failure>
+			<error message="Error" type="">setupfailing1/failing_test.go:4: cannot find package &#34;other/package&#34; in any of:&#xA;&#x9;/path/vendor (vendor tree)&#xA;&#x9;/path/go/root (from $GOROOT)&#xA;&#x9;/path/go/path (from $GOPATH)</error>
 		</testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/32-report.xml
+++ b/testdata/32-report.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-	<testsuite tests="2" failures="1" time="0.005" name="github.com/jstemmer/test/failedsummary">
+	<testsuite tests="2" failures="0" errors="1" time="0.005" name="github.com/jstemmer/test/failedsummary">
 		<properties>
 			<property name="go.version" value="1.0"></property>
 		</properties>
 		<testcase classname="failedsummary" name="TestOne" time="0.000"></testcase>
-		<testcase classname="failedsummary" name="Failure" time="0.000">
-			<failure message="Failed" type="">panic: panic</failure>
+		<testcase classname="failedsummary" name="Error" time="0.000">
+			<error message="Error" type="">panic: panic</error>
 		</testcase>
 	</testsuite>
 </testsuites>

--- a/testdata/33-report.xml
+++ b/testdata/33-report.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="5" failures="1" errors="0" time="0.610" name="github.com/maintainer/repo/package1">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+			<property name="coverage.statements.pct" value="20.0"></property>
+		</properties>
+		<testcase classname="package1" name="TestParent/child1" time="0.090"></testcase>
+		<testcase classname="package1" name="TestParent/child2" time="0.090"></testcase>
+		<testcase classname="package1" name="TestParent/failureChild3" time="0.420">
+			<failure message="Failed" type="">    example.go:123: &#xA;        &#x9;Error Trace:&#x9;example.go:123&#xA;        &#x9;Error:      &#x9;Not equal:&#xA;        &#x9;            &#x9;expected: 1&#xA;        &#x9;            &#x9;actual: 2&#xA;        &#x9;Test:       &#x9;TestParent/failureChild3</failure>
+		</testcase>
+		<testcase classname="package1" name="TestParent/skippedChild4" time="0.000">
+			<skipped message=""></skipped>
+		</testcase>
+		<testcase classname="package1" name="TestTwo" time="0.010"></testcase>
+	</testsuite>
+	<testsuite tests="1" failures="0" errors="0" time="1.020" name="github.com/maintainer/repo/package2">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+			<property name="coverage.statements.pct" value="12.5"></property>
+		</properties>
+		<testcase classname="package2" name="TestPackage2" time="1.020"></testcase>
+	</testsuite>
+</testsuites>

--- a/testdata/33-subtest.txt
+++ b/testdata/33-subtest.txt
@@ -1,0 +1,26 @@
+=== RUN TestParent
+=== RUN TestParent/child1
+=== RUN TestParent/child2
+=== RUN TestParent/failureChild3
+    example.go:123: 
+        	Error Trace:	example.go:123
+        	Error:      	Not equal:
+        	            	expected: 1
+        	            	actual: 2
+        	Test:       	TestParent/failureChild3
+=== RUN TestParent/skippedChild4
+--- FAIL: TestParent (0.60s)
+    --- PASS: TestParent/child1 (0.09s)
+    --- PASS: TestParent/child2 (0.09s)
+    --- FAIL: TestParent/failureChild3 (0.42s)
+    --- SKIP: TestParent/skippedChild4 (0.00s)
+=== RUN TestTwo
+--- PASS: TestTwo (0.01s)
+FAIL
+coverage: 20.0% of statements in github.com/maintainer/repo/package1, github.com/maintainer/repo/package2
+FAIL    github.com/maintainer/repo/package1 0.61s
+=== RUN TestPackage2
+--- PASS: TestPackage2 (1.02s)
+coverage: 12.5% of statements in github.com/maintainer/repo/package1, github.com/maintainer/repo/package2
+ok      github.com/maintainer/repo/package2 1.02s    coverage: 12.5% of statements in github.com/maintainer/repo/package1, github.com/maintainer/repo/package2
+FAIL


### PR DESCRIPTION
All changes are intended to be compliant with the JUnit schema found here: https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd

## Several changes in one MR here, so to break it down:
### Add flag to remove parent test from sub-tests (cases)
#### Issues: #72
  If any sub-test within a function failed, the parent function is also logged as a failure. This can be
  misleading when viewing test results, so the option to ignore these parent lines has been added.
### Enhance multi-line support
#### Issues: #80 #18
  Only some test output was being written to the buffer, which overwrote anything
  set directly. Changed to always write to the buffer on output.
### Populate "system-out" attribute with log results on PASS
#### Issues: #108 
  Uses the HTML string escaper to safely set the output.
### Differentiate between "Errors" and "Failures"
#### Issues: #101 #105 
  If it goes wrong within a test (mismatched output, unexpected error returned, etc.), it's classified as a "Failure".
  The remainder of the cases fall into either build errors, or unexpected panics, which are both classified as "Errors".