### PR TITLE
added -output parameter

### DIFF
--- a/go-junit-report.go
+++ b/go-junit-report.go
@@ -14,6 +14,7 @@ var (
 	packageName   = flag.String("package-name", "", "specify a package name (compiled test have no package name in output)")
 	goVersionFlag = flag.String("go-version", "", "specify the value to use for the go.version property in the generated XML")
 	setExitCode   = flag.Bool("set-exit-code", false, "set exit code to 1 if tests failed")
+	outputFile    = flag.String("output", "", "write junit report to a file and show regular go test output on the console")
 )
 
 func main() {
@@ -26,14 +27,27 @@ func main() {
 	}
 
 	// Read input
-	report, err := parser.Parse(os.Stdin, *packageName)
+	report, err := parser.Parse(os.Stdin, *packageName, *outputFile != "")
 	if err != nil {
 		fmt.Printf("Error reading input: %s\n", err)
 		os.Exit(1)
 	}
 
+	// set up the output stream
+	outStream := os.Stdout
+	if *outputFile != "" {
+		outStream, err = os.Create(*outputFile)
+		if err != nil {
+			fmt.Printf("Error creating file: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
 	// Write xml
-	err = formatter.JUnitReportXML(report, *noXMLHeader, *goVersionFlag, os.Stdout)
+	err = formatter.JUnitReportXML(report, *noXMLHeader, *goVersionFlag, outStream)
+	if outStream != os.Stdout {
+		outStream.Close()
+	}
 	if err != nil {
 		fmt.Printf("Error writing XML: %s\n", err)
 		os.Exit(1)

--- a/go-junit-report_test.go
+++ b/go-junit-report_test.go
@@ -1550,7 +1550,7 @@ func TestParser(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		report, err := parser.Parse(file, testCase.packageName)
+		report, err := parser.Parse(file, testCase.packageName, false)
 		if err != nil {
 			t.Fatalf("error parsing: %s", err)
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bufio"
 	"io"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -74,7 +75,7 @@ var (
 // Parse parses go test output from reader r and returns a report with the
 // results. An optional pkgName can be given, which is used in case a package
 // result line is missing.
-func Parse(r io.Reader, pkgName string) (*Report, error) {
+func Parse(r io.Reader, pkgName string, showOutput bool) (*Report, error) {
 	reader := bufio.NewReader(r)
 
 	report := &Report{make([]Package, 0)}
@@ -113,6 +114,10 @@ func Parse(r io.Reader, pkgName string) (*Report, error) {
 		}
 
 		line := string(l)
+
+		if showOutput {
+			fmt.Println(line)
+		}
 
 		if strings.HasPrefix(line, "=== RUN ") {
 			// new test


### PR DESCRIPTION
Sometimes it can be useful to see the original `go test` output along with creating the report. For example, in a CI system you can have the job log and the XML artifact. For this purpose I have added a `-output` parameter to output the JUnit report XML to a file, and to show the original `go test` output on the console.