### PR TITLE
go-junit-report_test should fail if no files found

### DIFF
--- a/internal/gojunitreport/go-junit-report_test.go
+++ b/internal/gojunitreport/go-junit-report_test.go
@@ -33,6 +33,9 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error finding files in testdata: %v", err)
 	}
+	if len(files) == 0 {
+		t.Fatalf("no files found in %s", testDataDir)
+	}
 
 	for _, file := range files {
 		if !matchRegex.MatchString(file) {


### PR DESCRIPTION
Today, if the testdata directory isn't present, this test trivially passes. This makes it fail when no files are found.