### PR TITLE
Report stores a slice of Property structs instead of a map

### DIFF
--- a/gtr/gtr.go
+++ b/gtr/gtr.go
@@ -78,7 +78,7 @@ func (p *Package) SetProperty(key, value string) {
 	// then add the specieid key-value property.
 	i := 0
 	for _, prop := range p.Properties {
-		if key == prop.Name {
+		if key != prop.Name {
 			p.Properties[i] = prop
 			i++
 		}

--- a/gtr/gtr.go
+++ b/gtr/gtr.go
@@ -61,7 +61,7 @@ type Package struct {
 	Duration   time.Duration
 	Coverage   float64
 	Output     []string
-	Properties map[string]string
+	Properties []Property
 
 	Tests []Test
 
@@ -73,10 +73,28 @@ type Package struct {
 // property with the given key already exists, its old value will be
 // overwritten with the given value.
 func (p *Package) SetProperty(key, value string) {
-	if p.Properties == nil {
-		p.Properties = make(map[string]string)
+	// TODO(jstemmer): Delete this method in the next major release.
+	// Delete all the properties whose name is the specified key,
+	// then add the specieid key-value property.
+	i := 0
+	for _, prop := range p.Properties {
+		if key == prop.Name {
+			p.Properties[i] = prop
+			i++
+		}
 	}
-	p.Properties[key] = value
+	p.Properties = p.Properties[:i]
+	p.AddProperty(key, value)
+}
+
+// AddProperty appends a name/value property in the current package.
+func (p *Package) AddProperty(name, value string) {
+	p.Properties = append(p.Properties, Property{Name: name, Value: value})
+}
+
+// Property is a name/value property.
+type Property struct {
+	Name, Value string
 }
 
 // Test contains the results of a single test.

--- a/gtr/gtr_test.go
+++ b/gtr/gtr_test.go
@@ -1,6 +1,10 @@
 package gtr
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestTrimPrefixSpaces(t *testing.T) {
 	tests := []struct {
@@ -22,5 +26,17 @@ func TestTrimPrefixSpaces(t *testing.T) {
 		if got != test.want {
 			t.Errorf("TrimPrefixSpaces(%q, %d) incorrect, got %q, want %q", test.input, test.indent, got, test.want)
 		}
+	}
+}
+
+func TestSetProperty(t *testing.T) {
+	pkg := Package{}
+	pkg.SetProperty("a", "b")
+	pkg.SetProperty("c", "d")
+	pkg.SetProperty("a", "e")
+
+	want := []Property{{Name: "c", Value: "d"}, {Name: "a", Value: "e"}}
+	if diff := cmp.Diff(want, pkg.Properties); diff != "" {
+		t.Errorf("SetProperty got unexpected diff: %s", diff)
 	}
 }

--- a/junit/junit.go
+++ b/junit/junit.go
@@ -144,8 +144,8 @@ func CreateFromReport(report gtr.Report, hostname string) Testsuites {
 			suite.SetTimestamp(pkg.Timestamp)
 		}
 
-		for k, v := range pkg.Properties {
-			suite.AddProperty(k, v)
+		for _, p := range pkg.Properties {
+			suite.AddProperty(p.Name, p.Value)
 		}
 
 		if len(pkg.Output) > 0 {

--- a/junit/junit_test.go
+++ b/junit/junit_test.go
@@ -19,7 +19,7 @@ func TestCreateFromReport(t *testing.T) {
 				Duration:   1 * time.Second,
 				Coverage:   0.9,
 				Output:     []string{"output"},
-				Properties: map[string]string{"go.version": "go1.18"},
+				Properties: []gtr.Property{{Name: "go.version", Value: "go1.18"}},
 				Tests: []gtr.Test{
 					{
 						Name:   "TestPass",


### PR DESCRIPTION
Report stores a slice of Property structs instead of a map to mimic JUnit properties, which have a deterministic ordering and allow multipler properties with the same name.