### PR TITLE
Fix regular expression for summary with "no statements" coverage.

### DIFF
--- a/parser/gotest/gotest.go
+++ b/parser/gotest/gotest.go
@@ -37,11 +37,12 @@ var (
 		`(?:\s+(\d+\.\d+)s)?` +
 		// 4: cached indicator (optional)
 		`(?:\s+(\(cached\)))?` +
-		// 5: [status message] (optional)
+		// 5: coverage percentage (optional)
+		// 6: coverage package list (optional)
+		`(?:\s+coverage:\s+(?:\[no\sstatements\]|(\d+\.\d+)%\sof\sstatements(?:\sin\s(.+))?))?` +
+		// 7: [status message] (optional)
 		`(?:\s+(\[[^\]]+\]))?` +
-		// 6: coverage percentage (optional)
-		// 7: coverage package list (optional)
-		`(?:\s+coverage:\s+(\d+\.\d+)%\sof\sstatements(?:\sin\s(.+))?)?$`)
+		`$`)
 )
 
 // Option defines options that can be passed to gotest.New.
@@ -200,7 +201,7 @@ func (p *Parser) parseLine(line string) (events []Event) {
 	} else if matches := regexStatus.FindStringSubmatch(line); len(matches) == 2 {
 		return p.status(matches[1])
 	} else if matches := regexSummary.FindStringSubmatch(line); len(matches) == 8 {
-		return p.summary(matches[1], matches[2], matches[3], matches[4], matches[5], matches[6], matches[7])
+		return p.summary(matches[1], matches[2], matches[3], matches[4], matches[7], matches[5], matches[6])
 	} else if matches := regexCoverage.FindStringSubmatch(line); len(matches) == 3 {
 		return p.coverage(matches[1], matches[2])
 	} else if matches := regexBenchmark.FindStringSubmatch(line); len(matches) == 2 {

--- a/parser/gotest/gotest_test.go
+++ b/parser/gotest/gotest_test.go
@@ -92,6 +92,18 @@ var parseLineTests = []parseLineTest{
 		[]Event{{Type: "summary", Name: "package/other", Result: "ok", Data: "(cached)"}},
 	},
 	{
+		"ok  	package/name 0.400s  coverage: [no statements]",
+		[]Event{{Type: "summary", Name: "package/name", Result: "ok", Duration: 400 * time.Millisecond}},
+	},
+	{
+		"ok  	package/name 0.400s  (cached) coverage: [no statements]",
+		[]Event{{Type: "summary", Name: "package/name", Result: "ok", Duration: 400 * time.Millisecond, Data: "(cached)"}},
+	},
+	{
+		"ok  	package/name 0.001s  coverage: [no statements] [no tests to run]",
+		[]Event{{Type: "summary", Name: "package/name", Result: "ok", Duration: 1 * time.Millisecond, Data: "[no tests to run]"}},
+	},
+	{
 		"ok  	package/name 0.400s  coverage: 10.0% of statements",
 		[]Event{{Type: "summary", Name: "package/name", Result: "ok", Duration: 400 * time.Millisecond, CovPct: 10}},
 	},
@@ -110,6 +122,10 @@ var parseLineTests = []parseLineTest{
 	{
 		"ok  	package/name	(cached) [no tests to run]",
 		[]Event{{Type: "summary", Name: "package/name", Result: "ok", Data: "(cached) [no tests to run]"}},
+	},
+	{
+		"ok   package/name 0.042s  coverage: 0.0% of statements [no tests to run]",
+		[]Event{{Type: "summary", Name: "package/name", Result: "ok", Duration: 42 * time.Millisecond, CovPct: 0, Data: "[no tests to run]"}},
 	},
 	{
 		"coverage: 10% of statements",
@@ -199,7 +215,7 @@ func TestParseLine(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			parser := NewParser()
 			events := parser.parseLine(test.input)
-			if diff := cmp.Diff(events, test.events); diff != "" {
+			if diff := cmp.Diff(test.events, events); diff != "" {
 				t.Errorf("parseLine(%q) returned unexpected events, diff (-want, +got):\n%v", test.input, diff)
 			}
 		})


### PR DESCRIPTION
The current regular expression doesn't cover the case when the coverage is "no statement". This causes the specific package being "left over" when creating the report.