### PR TITLE
Change properties to be a slice instead of a pointer of slice.

### DIFF
--- a/junit/junit.go
+++ b/junit/junit.go
@@ -54,21 +54,16 @@ type Testsuite struct {
 	Timestamp string `xml:"timestamp,attr,omitempty"` // date and time in ISO8601
 	File      string `xml:"file,attr,omitempty"`
 
-	Properties *[]Property `xml:"properties>property,omitempty"`
-	Testcases  []Testcase  `xml:"testcase,omitempty"`
-	SystemOut  *Output     `xml:"system-out,omitempty"`
-	SystemErr  *Output     `xml:"system-err,omitempty"`
+	Properties []Property `xml:"properties>property,omitempty"`
+	Testcases  []Testcase `xml:"testcase,omitempty"`
+	SystemOut  *Output    `xml:"system-out,omitempty"`
+	SystemErr  *Output    `xml:"system-err,omitempty"`
 }
 
 // AddProperty adds a property with the given name and value to this Testsuite.
 func (t *Testsuite) AddProperty(name, value string) {
 	prop := Property{Name: name, Value: value}
-	if t.Properties == nil {
-		t.Properties = &[]Property{prop}
-		return
-	}
-	props := append(*t.Properties, prop)
-	t.Properties = &props
+	t.Properties = append(t.Properties, prop)
 }
 
 // AddTestcase adds Testcase tc to this Testsuite.

--- a/junit/junit_test.go
+++ b/junit/junit_test.go
@@ -66,7 +66,7 @@ func TestCreateFromReport(t *testing.T) {
 				Skipped:   1,
 				Time:      "1.000",
 				Timestamp: "2022-06-26T00:00:00Z",
-				Properties: &[]Property{
+				Properties: []Property{
 					{Name: "go.version", Value: "go1.18"},
 					{Name: "coverage.statements.pct", Value: "0.90"},
 				},
@@ -144,7 +144,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 				Skipped:   1,
 				Time:      "12.345",
 				Timestamp: "2012-03-09T14:38:06+01:00",
-				Properties: &[]Property{
+				Properties: []Property{
 					{Name: "key", Value: "value"},
 				},
 				Testcases: []Testcase{


### PR DESCRIPTION
A pointer of slice is rather wried in Go. Is there any particular reason why we shouldn't use slice directly?