### PR TITLE
fix: properly parse resume prefix for gotest 1.20

### DIFF
--- a/parser/gotest/gotest.go
+++ b/parser/gotest/gotest.go
@@ -191,6 +191,9 @@ func (p *Parser) parseLine(line string) (events []Event) {
 		return p.pauseTest(strings.TrimSpace(line[10:]))
 	} else if strings.HasPrefix(line, "=== CONT ") {
 		return p.contTest(strings.TrimSpace(line[9:]))
+	} else if strings.HasPrefix(line, "=== NAME ") {
+		// for compatibility with gotest 1.20+ https://go-review.git.corp.google.com/c/go/+/443596
+		return p.contTest(strings.TrimSpace(line[9:]))
 	} else if matches := regexEndTest.FindStringSubmatch(line); len(matches) == 5 {
 		return p.endTest(line, matches[1], matches[2], matches[3], matches[4])
 	} else if matches := regexStatus.FindStringSubmatch(line); len(matches) == 2 {

--- a/parser/gotest/gotest_test.go
+++ b/parser/gotest/gotest_test.go
@@ -45,6 +45,10 @@ var parseLineTests = []parseLineTest{
 		[]Event{{Type: "cont_test", Name: "TestOne"}},
 	},
 	{
+		"=== NAME  TestOne",
+		[]Event{{Type: "cont_test", Name: "TestOne"}},
+	},
+	{
 		"--- PASS: TestOne (12.34 seconds)",
 		[]Event{{Type: "end_test", Name: "TestOne", Result: "PASS", Duration: 12_340 * time.Millisecond}},
 	},


### PR DESCRIPTION
gotest 1.20 replaced the CONT prefix with NAME. This updates the gotest parsing logic to support the new output format.

See: https://go-review.git.corp.google.com/c/go/+/443596

Fixes: https://github.com/jstemmer/go-junit-report/issues/169