### PR TITLE
fix: parse output from parallel tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 go-junit-report
 build/
+.idea

--- a/parser/gotest/event.go
+++ b/parser/gotest/event.go
@@ -34,4 +34,5 @@ func (e *Event) applyMetadata(m *reader.Metadata) {
 		return
 	}
 	e.Package = m.Package
+	e.Name = m.Test
 }

--- a/parser/gotest/internal/reader/reader.go
+++ b/parser/gotest/internal/reader/reader.go
@@ -17,6 +17,7 @@ type LineReader interface {
 // Metadata contains metadata that belongs to a line.
 type Metadata struct {
 	Package string
+	Test    string
 }
 
 // LimitedLineReader reads lines from an io.Reader object with a configurable
@@ -117,6 +118,6 @@ func (r *JSONEventReader) ReadLine() (string, *Metadata, error) {
 			// Skip events without output
 			continue
 		}
-		return strings.TrimSuffix(event.Output, "\n"), &Metadata{Package: event.Package}, nil
+		return strings.TrimSuffix(event.Output, "\n"), &Metadata{Package: event.Package, Test: event.Test}, nil
 	}
 }

--- a/parser/gotest/report_builder.go
+++ b/parser/gotest/report_builder.go
@@ -92,7 +92,13 @@ func (b *reportBuilder) ProcessEvent(ev Event) {
 		b.CreateBuildError(ev.Name)
 	case "output":
 		if ev.Package != "" {
-			b.getPackageBuilder(ev.Package).Output(ev.Data)
+			pb := b.getPackageBuilder(ev.Package)
+			testName, _, _ := strings.Cut(ev.Data, " ")
+			id, found := pb.findTest(testName)
+			if !found {
+				id, _ = pb.findTest(ev.Name)
+			}
+			pb.Output(id, ev.Data)
 		} else {
 			b.output.Append(ev.Data)
 		}
@@ -443,8 +449,8 @@ func (b *packageBuilder) Coverage(pct float64, packages []string) {
 }
 
 // Output appends data to the output of this package.
-func (b *packageBuilder) Output(data string) {
-	b.output.Append(data)
+func (b *packageBuilder) Output(id int, data string) {
+	b.output.AppendToID(id, data)
 }
 
 // findTest returns the id of the most recently created test with the given


### PR DESCRIPTION
- Update packageBuilder output behavior to be by id
- Update package output switch to include looking up test name before adding output
- Overrides behavior of setting active ID with `--- CONT` event to always select output id at the time of line parsing