### PR TITLE
add name property to <testsuites> element

### DIFF
--- a/junit/junit.go
+++ b/junit/junit.go
@@ -146,7 +146,7 @@ type Output struct {
 
 // CreateFromReport creates a JUnit representation of the given gtr.Report.
 func CreateFromReport(report gtr.Report, hostname string) Testsuites {
-	var suites Testsuites
+	var suites Testsuites = Testsuites{Name: "go tests"}
 	for _, pkg := range report.Packages {
 		var duration time.Duration
 		suite := Testsuite{

--- a/junit/junit_test.go
+++ b/junit/junit_test.go
@@ -53,6 +53,7 @@ func TestCreateFromReport(t *testing.T) {
 	}
 
 	want := Testsuites{
+		Name:     "go tests",
 		Tests:    7,
 		Errors:   3,
 		Failures: 1,

--- a/testdata/001-report.xml
+++ b/testdata/001-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="5" failures="1" skipped="2">
+<testsuites name="go tests" tests="5" failures="1" skipped="2">
 	<testsuite name="package/pass" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="0.160" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/005-report.xml
+++ b/testdata/005-report.xml
@@ -1,4 +1,4 @@
-<testsuites tests="2">
+<testsuites name="go tests" tests="2">
 	<testsuite name="package/pass" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="0.160" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/007-report.xml
+++ b/testdata/007-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2">
+<testsuites name="go tests" tests="2">
 	<testsuite name="test/package" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="0.160" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/008-report.xml
+++ b/testdata/008-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="3" failures="3">
+<testsuites name="go tests" tests="3" failures="3">
 	<testsuite name="package/parallel" tests="3" failures="3" errors="0" id="0" hostname="hostname" time="0.102" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/009-report.xml
+++ b/testdata/009-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2">
+<testsuites name="go tests" tests="2">
 	<testsuite name="package/name" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="0.160" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/010-report.xml
+++ b/testdata/010-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="3">
+<testsuites name="go tests" tests="3">
 	<testsuite name="package1/foo" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="0.400" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/011-report.xml
+++ b/testdata/011-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2">
+<testsuites name="go tests" tests="2">
 	<testsuite name="package/name" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="0.050" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/012-report.xml
+++ b/testdata/012-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="11" failures="4" skipped="1">
+<testsuites name="go tests" tests="11" failures="4" skipped="1">
 	<testsuite name="package/subtests" tests="11" failures="4" errors="0" id="0" hostname="hostname" skipped="1" time="0.001" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/013-report.xml
+++ b/testdata/013-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="5" errors="3">
+<testsuites name="go tests" tests="5" errors="3">
 	<testsuite name="package/name/passing1" tests="1" failures="0" errors="0" id="0" hostname="hostname" time="0.100" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/014-report.xml
+++ b/testdata/014-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2" errors="2">
+<testsuites name="go tests" tests="2" errors="2">
 	<testsuite name="package/panic" tests="1" failures="0" errors="1" id="0" hostname="hostname" time="0.003" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/015-report.xml
+++ b/testdata/015-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="go tests">
 	<testsuite name="package/empty" tests="0" failures="0" errors="0" id="0" hostname="hostname" time="0.001" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/016-report.xml
+++ b/testdata/016-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="3">
+<testsuites name="go tests" tests="3">
 	<testsuite name="package/repeated-names" tests="3" failures="0" errors="0" id="0" hostname="hostname" time="0.001" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/017-report.xml
+++ b/testdata/017-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1" failures="1">
+<testsuites name="go tests" tests="1" failures="1">
 	<testsuite name="package/race" tests="1" failures="1" errors="0" id="0" hostname="hostname" time="0.005" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/018-report.xml
+++ b/testdata/018-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="3">
+<testsuites name="go tests" tests="3">
 	<testsuite name="package1/foo" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="0.400" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/019-report.xml
+++ b/testdata/019-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2">
+<testsuites name="go tests" tests="2">
 	<testsuite name="package/name" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="0.160" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/021-report.xml
+++ b/testdata/021-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1">
+<testsuites name="go tests" tests="1">
 	<testsuite name="package/one" tests="1" failures="0" errors="0" id="0" hostname="hostname" time="0.000" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/022-report.xml
+++ b/testdata/022-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="3">
+<testsuites name="go tests" tests="3">
 	<testsuite name="package/bench" tests="3" failures="0" errors="0" id="0" hostname="hostname" time="1.640" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/023-report.xml
+++ b/testdata/023-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2">
+<testsuites name="go tests" tests="2">
 	<testsuite name="package/one" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="9.415" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/024-report.xml
+++ b/testdata/024-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2">
+<testsuites name="go tests" tests="2">
 	<testsuite name="package/bench" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="1.642" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/025-report.xml
+++ b/testdata/025-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2">
+<testsuites name="go tests" tests="2">
 	<testsuite name="pkg/count" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="14.211" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/026-report.xml
+++ b/testdata/026-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="6">
+<testsuites name="go tests" tests="6">
 	<testsuite name="mycode/common" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="7.267" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/027-report.xml
+++ b/testdata/027-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="3">
+<testsuites name="go tests" tests="3">
 	<testsuite name="really/small" tests="3" failures="0" errors="0" id="0" hostname="hostname" time="4.344" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/028-report.xml
+++ b/testdata/028-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1">
+<testsuites name="go tests" tests="1">
 	<testsuite name="single/cpu" tests="1" failures="0" errors="0" id="0" hostname="hostname" time="9.467" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/029-report.xml
+++ b/testdata/029-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1">
+<testsuites name="go tests" tests="1">
 	<testsuite name="sixteen/cpu" tests="1" failures="0" errors="0" id="0" hostname="hostname" time="1.522" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/030-report.xml
+++ b/testdata/030-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="17" failures="9">
+<testsuites name="go tests" tests="17" failures="9">
 	<testsuite name="package/stdout" tests="17" failures="9" errors="0" id="0" hostname="hostname" time="0.001" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/031-report.xml
+++ b/testdata/031-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="5" errors="3">
+<testsuites name="go tests" tests="5" errors="3">
 	<testsuite name="package/name/passing1" tests="1" failures="0" errors="0" id="0" hostname="hostname" time="0.100" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/032-report.xml
+++ b/testdata/032-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2" errors="1">
+<testsuites name="go tests" tests="2" errors="1">
 	<testsuite name="github.com/jstemmer/test/failedsummary" tests="2" failures="0" errors="1" id="0" hostname="hostname" time="0.005" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/033-report.xml
+++ b/testdata/033-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2">
+<testsuites name="go tests" tests="2">
 	<testsuite name="compress/flate" tests="2" failures="0" errors="0" id="0" hostname="hostname" time="83.202" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/034-report.xml
+++ b/testdata/034-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="go tests">
 	<testsuite name="package/name" tests="0" failures="0" errors="0" id="0" hostname="hostname" time="0.000" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/035-report.xml
+++ b/testdata/035-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="9">
+<testsuites name="go tests" tests="9">
 	<testsuite name="package/whitespace" tests="9" failures="0" errors="0" id="0" hostname="hostname" time="0.001" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/036-report.xml
+++ b/testdata/036-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="3" failures="2" skipped="1">
+<testsuites name="go tests" tests="3" failures="2" skipped="1">
 	<testsuite name="package/name/benchfail" tests="3" failures="2" errors="0" id="0" hostname="hostname" skipped="1" time="0.002" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/037-report.xml
+++ b/testdata/037-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2" failures="1">
+<testsuites name="go tests" tests="2" failures="1">
 	<testsuite name="package/name" tests="2" failures="1" errors="0" id="0" hostname="hostname" time="0.151" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/038-report.xml
+++ b/testdata/038-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1" errors="1">
+<testsuites name="go tests" tests="1" errors="1">
 	<testsuite name="package/testpkg/pkg" tests="1" failures="0" errors="1" id="0" hostname="hostname" time="0.000" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/039-report.xml
+++ b/testdata/039-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1">
+<testsuites name="go tests" tests="1">
 	<testsuite name="package/pass" tests="1" failures="0" errors="0" id="0" hostname="hostname" time="0.160" timestamp="2022-01-01T00:00:00Z">
 		<testcase name="TestPass" classname="package/pass" time="0.060"></testcase>
 	</testsuite>

--- a/testdata/100-report.xml
+++ b/testdata/100-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1">
+<testsuites name="go tests" tests="1">
 	<testsuite name="package/name/ok" tests="1" failures="0" errors="0" id="0" hostname="hostname" time="0.001" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/101-report.xml
+++ b/testdata/101-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2" failures="1">
+<testsuites name="go tests" tests="2" failures="1">
 	<testsuite name="package/name/fail" tests="2" failures="1" errors="0" id="0" hostname="hostname" time="0.001" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/102-report.xml
+++ b/testdata/102-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1" errors="1">
+<testsuites name="go tests" tests="1" errors="1">
 	<testsuite name="package/name/broken" tests="1" failures="0" errors="1" id="0" hostname="hostname" time="0.000" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/103-report.xml
+++ b/testdata/103-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="4" failures="2">
+<testsuites name="go tests" tests="4" failures="2">
 	<testsuite name="package/name/subtest" tests="4" failures="2" errors="0" id="0" hostname="hostname" time="0.001" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/104-report.xml
+++ b/testdata/104-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1" failures="1">
+<testsuites name="go tests" tests="1" failures="1">
 	<testsuite name="package/name/race" tests="1" failures="1" errors="0" id="0" hostname="hostname" time="0.005" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/105-report.xml
+++ b/testdata/105-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="1" errors="1">
+<testsuites name="go tests" tests="1" errors="1">
 	<testsuite name="package/name/panic" tests="1" failures="0" errors="1" id="0" hostname="hostname" time="0.003" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/106-report.xml
+++ b/testdata/106-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="3" errors="1">
+<testsuites name="go tests" tests="3" errors="1">
 	<testsuite name="package/name/main/ack" tests="1" failures="0" errors="0" id="0" hostname="hostname" time="0.000" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/107-report.xml
+++ b/testdata/107-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2" skipped="2">
+<testsuites name="go tests" tests="2" skipped="2">
 	<testsuite name="package/name/skip" tests="2" failures="0" errors="0" id="0" hostname="hostname" skipped="2" time="0.001" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/108-report.xml
+++ b/testdata/108-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2" errors="1">
+<testsuites name="go tests" tests="2" errors="1">
 	<testsuite name="package/name/paniclate" tests="2" failures="0" errors="1" id="0" hostname="hostname" time="0.003" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/109-report.xml
+++ b/testdata/109-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="4">
+<testsuites name="go tests" tests="4">
 	<testsuite name="package/name/bench" tests="4" failures="0" errors="0" id="0" hostname="hostname" time="0.762" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/110-report.xml
+++ b/testdata/110-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="3" failures="2" skipped="1">
+<testsuites name="go tests" tests="3" failures="2" skipped="1">
 	<testsuite name="package/name/benchfail" tests="3" failures="2" errors="0" id="0" hostname="hostname" skipped="1" time="0.002" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/111-report.xml
+++ b/testdata/111-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
+<testsuites name="go tests">
 	<testsuite name="package/name/empty" tests="0" failures="0" errors="0" id="0" hostname="hostname" time="0.001" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/112-report.xml
+++ b/testdata/112-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="3" failures="3">
+<testsuites name="go tests" tests="3" failures="3">
 	<testsuite name="package/name/parallel" tests="3" failures="3" errors="0" id="0" hostname="hostname" time="0.001" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>

--- a/testdata/113-report.xml
+++ b/testdata/113-report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2">
+<testsuites name="go tests" tests="2">
 	<testsuite name="package/race-json/pkg2" tests="1" failures="0" errors="0" id="0" hostname="hostname" time="0.000" timestamp="2022-01-01T00:00:00Z">
 		<properties>
 			<property name="go.version" value="1.0"></property>


### PR DESCRIPTION
this lines up with behaviour in Jest and Vitest's JUnit reporters. this information is helpful for processing JUnit XML's based on what framework generated the report.